### PR TITLE
refactor: effective claims and headers validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Unreleased
 
+### :sparkles: New
+
+- validate claims or headers with custom pydantic models for `decode()` ([#21])
+
 ### :gear: Changes
 
 - Refactoring of `JWTClaims` pydantic model ([#17])
     - defaulting with no `'iat'` set
     - `with_issued_at()` method added
     - modular model with reusable mixins
+- Refactoring of claims and headers validation ([#21])
+    - `encode()` and `decode()` have now the same validation behavior with `claims_validation_model` and `headers_validation_model` parameters. Disable it by setting to `None`
 
 ## v0.2.0 (2025-12-27)
 
@@ -41,7 +47,7 @@
 
 :tada: superjwt repository initialization
 
-
+[#21]: /../../issues/21
 [#17]: /../../issues/17
 [#15]: /../../issues/15
 [#14]: /../../issues/14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ select = [
 ignore = [
     "E501",  # line length (handled by Black)
     "N803",  # argument name should be lowercase
+    "N806",  # variable in function should be lowercase
 ]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -28,6 +28,7 @@ from superjwt.exceptions import (
     AlgorithmNotSupportedError,
     InvalidAlgorithmError,
     InvalidHeaderError,
+    JWTError,
 )
 from superjwt.keys import BaseKey, NoneKey, OctetKey
 
@@ -294,6 +295,11 @@ class JWSTokenDecoded(BaseModel):
     signature: SecretBytes
 
 
+class JWSTokenModel(BaseModel):
+    headers: JOSEHeader | None = None
+    claims: JWTBaseModel | None = None
+
+
 MAX_TOKEN_LENGTH: int = 16 * 1024  # 16 KB
 
 
@@ -304,6 +310,7 @@ class JWSToken(BaseModel):
     decoded: JWSTokenDecoded = JWSTokenDecoded(
         header={}, payload={}, signature=SecretBytes(b"")
     )
+    model: JWSTokenModel = JWSTokenModel()
 
 
 class JWSTokenLifeCycle(BaseModel):
@@ -326,3 +333,56 @@ def get_jws_algorithm(algorithm: Algorithm | Literal["none"]) -> BaseJWSAlgorith
 def make_key(algorithm: Algorithm | Literal["none"], key: str | bytes) -> BaseKey:
     key_type = get_jws_algorithm(algorithm).key_type
     return key_type.import_key(key)
+
+
+DefaultClaimsValidationModel = JWTClaims
+DefaultHeadersValidationModel = JOSEHeader
+
+
+def select_effective_validation_model(
+    data: JWTBaseModel | dict[str, Any] | None,
+    validation_model: type[JWTBaseModel] | None,
+    DefaultValidationModel: type[JWTBaseModel],
+) -> type[JWTBaseModel]:
+    # 1. case validation disabled
+    if validation_model is None:
+        return DefaultValidationModel
+    # 2. default case
+    elif validation_model is DefaultValidationModel:
+        # override with self model if data is a pydantic model
+        if isinstance(data, JWTBaseModel):
+            return data.__class__
+        else:
+            return DefaultValidationModel
+    # 3. custom validation model was provided, overrides default
+    elif issubclass(validation_model, JWTBaseModel):
+        return validation_model
+    raise JWTError("Invalid validation model type")
+
+
+def prepare_and_validate_model(
+    data: JWTBaseModel | dict[str, Any] | None,
+    EffectiveValidationModel: type[JWTBaseModel],
+    type_err_msg: str = "Wrong data type for pydantic model preparation",
+    default_value: dict[str, Any] = {},  # noqa: B006
+    disable_validation: bool = False,
+) -> JWTBaseModel:
+    # prepare data dict
+    # 1 . case data is None
+    if data is None:
+        data_dict = default_value
+    # 2. case data is a dict
+    elif isinstance(data, dict):
+        data_dict = data.copy()
+    # 3. case data is a pydantic model
+    elif isinstance(data, JWTBaseModel):
+        data_dict = data.to_dict()
+    else:
+        raise TypeError(type_err_msg)
+
+    # RETURN PYDANTIC MODEL WITH NO VALIDATION
+    if disable_validation:
+        return EffectiveValidationModel.model_construct(**data_dict)
+
+    # RETURN PYDANTIC MODEL WITH VALIDATION RUN
+    return EffectiveValidationModel(**data_dict)

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import SecretBytes, ValidationError
 
@@ -7,13 +7,17 @@ from superjwt.algorithms import BaseJWSAlgorithm, NoneAlgorithm
 from superjwt.definitions import (
     MAX_TOKEN_LENGTH,
     Algorithm,
+    DefaultHeadersValidationModel,
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
     JWTBaseModel,
     get_jws_algorithm,
+    prepare_and_validate_model,
+    select_effective_validation_model,
 )
 from superjwt.exceptions import (
+    HeaderValidationError,
     InvalidHeaderError,
     JWTError,
     MalformedTokenError,
@@ -56,16 +60,25 @@ class JWS:
         header: JOSEHeader,
         payload: JWTBaseModel,
         key: BaseKey,
+        headers_validation_model: type[JOSEHeader] | None,
     ) -> bytes:
         if self.token.validated.encoded.compact != b"..":
             raise JWTError("JWS instance data must be reset")
 
-        header_dict: dict[str, Any] = header.to_dict()
+        # check header is valid
+        header = self.prepare_headers(
+            header,
+            cast("Algorithm", self.algorithm.name),
+            validation_model=headers_validation_model,
+        )
+        self.token.validated.model.headers = header
+
+        header_dict = header.to_dict()
         encoded_header = json.dumps(header_dict, separators=(",", ":")).encode("utf-8")
         self.token.validated.decoded.header = header_dict
         self.token.validated.encoded.header = urlsafe_b64encode(encoded_header)
 
-        payload_dict: dict[str, Any] = payload.to_dict()
+        payload_dict = payload.to_dict()
         encoded_payload = json.dumps(payload_dict, separators=(",", ":")).encode("utf-8")
         self.token.validated.decoded.payload = payload_dict
         self.token.validated.encoded.payload = urlsafe_b64encode(encoded_payload)
@@ -81,7 +94,7 @@ class JWS:
         key: BaseKey,
         *,
         with_detached_payload: JWTBaseModel | None = None,
-        disable_headers_validation: bool = False,
+        headers_validation_model: type[JOSEHeader] | None,
     ) -> JWSToken:
         if (
             self.token.validated.encoded.compact != b".."
@@ -93,8 +106,11 @@ class JWS:
         self.decode_parts(token, with_detached_payload)
 
         # validate headers
-        if not disable_headers_validation:
-            self.validate_header()
+        self.validate_header(
+            self.token.unsafe.decoded.header,
+            cast("Algorithm", self.algorithm.name),
+            validation_model=headers_validation_model,
+        )
 
         # verify signature
         self.verify_signature(key)
@@ -198,24 +214,54 @@ class JWS:
             )
         )
 
-    def validate_header(self) -> bool:
-        if not self.token.unsafe.decoded.header:
-            raise JWTError("JWS header was not decoded yet")
+    @staticmethod
+    def prepare_headers(
+        headers: JOSEHeader | dict[str, Any] | None,
+        algorithm: Algorithm,
+        validation_model: type[JWTBaseModel] | None,
+    ) -> JOSEHeader:
+        EffectiveValidationModel = select_effective_validation_model(
+            headers,
+            validation_model,
+            DefaultHeadersValidationModel,
+        )
 
-        # check headers
         try:
-            header = JOSEHeader.model_validate(
-                self.token.unsafe.decoded.header, context=self.crit_headers_strict_check
+            return cast(
+                "JOSEHeader",
+                prepare_and_validate_model(
+                    data=headers,
+                    EffectiveValidationModel=EffectiveValidationModel,
+                    type_err_msg="headers must be a JOSEHeader instance or a dict",
+                    default_value=JOSEHeader.make_default(algorithm).to_dict(),
+                    disable_validation=validation_model is None,
+                ),
             )
         except ValidationError as e:
-            raise InvalidHeaderError("JWS header contains invalid data") from e
+            raise HeaderValidationError(validation_errors=e.errors()) from e
 
-        if header.alg != self.algorithm.name:
-            raise InvalidHeaderError(
-                f"JWS algorithm '{header.alg}' does not match expected '{self.algorithm.name}'"
-            )
+    def validate_header(
+        self,
+        headers: dict[str, Any],
+        algorithm: Algorithm,
+        validation_model: type[JOSEHeader] | None,
+    ) -> None:
+        headers_validated = self.prepare_headers(
+            headers=headers,
+            algorithm=algorithm,
+            validation_model=validation_model,
+        )
+        headers_validated = headers_validated.model_validate(
+            headers_validated, context=self.crit_headers_strict_check
+        )
 
-        return True
+        self.token.unsafe.model.headers = headers_validated
+
+        if validation_model is not None:
+            if headers_validated.alg != self.algorithm.name:
+                raise InvalidHeaderError(
+                    f"JWS algorithm '{headers_validated.alg}' does not match expected '{self.algorithm.name}'"
+                )
 
     def verify_signature(self, key: BaseKey) -> bool:
         if isinstance(self.algorithm, NoneAlgorithm) and not self._allow_none_algorithm:

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -5,15 +5,18 @@ from pydantic import ValidationError
 
 from superjwt.definitions import (
     Algorithm,
+    DefaultClaimsValidationModel,
+    DefaultHeadersValidationModel,
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
     JWTClaims,
     make_key,
+    prepare_and_validate_model,
+    select_effective_validation_model,
 )
 from superjwt.exceptions import (
     ClaimsValidationError,
-    HeaderValidationError,
     JWTError,
 )
 from superjwt.jws import JWS
@@ -27,7 +30,6 @@ class JWT:
     def __init__(self):
         self.jws: JWS
         self.token: JWSToken
-        self.JWTEffectiveClaims: type[JWTBaseModel]
 
     def reset_token(self) -> None:
         self.token = JWSToken()
@@ -38,22 +40,25 @@ class JWT:
         key: str | bytes | BaseKey,
         algorithm: Algorithm = "HS256",
         *,
+        claims_validation_model: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
         headers: JOSEHeader | dict[str, Any] | None = None,
-        disable_claims_validation: bool = False,
-        disable_headers_validation: bool = False,
+        headers_validation_model: type[JOSEHeader] | None = DefaultHeadersValidationModel,
     ) -> bytes:
         """Encode and sign the claims as a JWT token
 
         Args:
-            claims (JWTBaseModel | dict[str, Any] | None): Claims to include in the JWT.
-                Will use default claims if not provided ('iat')
+            claims (JWTBaseModel | dict[str, Any] | None): Claims to include in the JWT payload.
             key (str | bytes | BaseKey): The key instance to sign the JWT with.
             algorithm (Algorithm): The algorithm to use for signing the JWT.
-                Will default to 'HS256' (HMAC with SHA-256)
-            headers (JOSEHeader | dict[str, Any] | None, opt.): Headers to include in the JWT.
-                Will use default headers if not provided
-            disable_claims_validation (bool, opt.): If True, disables claims validation.
-            disable_headers_validation (bool, opt.): If True, disables headers validation.
+                Will default to 'HS256' (HMAC with SHA-256).
+            claims_validation_model (type[JWTBaseModel] | None, opt.): the pydantic model
+                to use for claims validation. If None, claims validation is disabled.
+                Default to DefaultClaimsValidationModel.
+            headers (JOSEHeader | dict[str, Any] | None, opt.): Custom JWS headers to include
+                in the JWT. Will use default JWS headers if not provided.
+            headers_validation_model (type[JOSEHeader] | None, opt.): the pydantic model
+                to use for headers validation. If None, headers validation is disabled.
+                Default to DefaultHeadersValidationModel.
 
         Returns:
             bytes: the encoded compact JWT token
@@ -62,12 +67,11 @@ class JWT:
         # reset session
         self.reset_token()
 
-        # prepare claims data
-        self.JWTEffectiveClaims = JWTClaims
-        claims = self.prepare_claims(claims, disable_claims_validation)
+        # prepare claims data and perform validation
+        claims = self.prepare_claims(claims, validation_model=claims_validation_model)
 
-        # prepare headers data
-        headers = self.prepare_headers(headers, algorithm, disable_headers_validation)
+        # prepare headers data (validation will be done later in JWS instance)
+        headers = JWS.prepare_headers(headers, algorithm, validation_model=None)
 
         # prepare key
         if not isinstance(key, BaseKey):
@@ -75,7 +79,13 @@ class JWT:
 
         # encode as JWS
         self.jws = JWS(algorithm)
-        self.jws.encode(header=headers, payload=claims, key=key)
+        self.jws.encode(
+            header=headers,
+            payload=claims,
+            key=key,
+            headers_validation_model=headers_validation_model,
+        )
+        self.jws.token.validated.model.claims = claims
 
         self.token = self.jws.token.validated
         return self.token.encoded.compact
@@ -93,55 +103,26 @@ class JWT:
 
         return self.token.encoded.compact
 
+    @staticmethod
     def prepare_claims(
-        self,
         claims: JWTBaseModel | dict[str, Any] | None,
-        disable_claims_validation: bool = False,
+        validation_model: type[JWTBaseModel] | None,
     ) -> JWTBaseModel:
-        if claims is None:
-            self.JWTEffectiveClaims = JWTClaims
-            claims_dict = {}
-        elif isinstance(claims, dict):
-            self.JWTEffectiveClaims = JWTClaims
-            claims_dict = claims.copy()
-        elif isinstance(claims, JWTBaseModel):
-            self.JWTEffectiveClaims = claims.__class__
-            claims_dict = claims.to_dict()
-        else:
-            raise TypeError("claims must be a JWTBaseModel instance or a dict")
-
-        if disable_claims_validation:
-            return self.JWTEffectiveClaims.model_construct(**claims_dict)
+        EffectiveValidationModel = select_effective_validation_model(
+            claims,
+            validation_model,
+            DefaultClaimsValidationModel,
+        )
 
         try:
-            return self.JWTEffectiveClaims(**claims_dict)
+            return prepare_and_validate_model(
+                data=claims,
+                EffectiveValidationModel=EffectiveValidationModel,
+                type_err_msg="claims must be a JWTBaseModel instance or a dict",
+                disable_validation=validation_model is None,
+            )
         except ValidationError as e:
             raise ClaimsValidationError(validation_errors=e.errors()) from e
-
-    def prepare_headers(
-        self,
-        headers: JOSEHeader | dict[str, Any] | None,
-        algorithm: Algorithm,
-        disable_headers_validation: bool = False,
-    ) -> JOSEHeader:
-        if headers is None:
-            return JOSEHeader.make_default(algorithm)
-
-        if isinstance(headers, dict):
-            self.JWTEffectiveClaims = JWTClaims
-            headers_dict = headers.copy()
-        elif isinstance(headers, JOSEHeader):
-            headers_dict = headers.to_dict()
-        else:
-            raise TypeError("headers must be a JOSEHeader instance or a dict")
-
-        if disable_headers_validation:
-            return JOSEHeader.model_construct(**headers_dict)
-
-        try:
-            return JOSEHeader(**headers_dict)
-        except ValidationError as e:
-            raise HeaderValidationError(validation_errors=e.errors()) from e
 
     def decode(
         self,
@@ -150,8 +131,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         with_detached_payload: JWTClaims | dict[str, Any] | None = None,
-        disable_claims_validation: bool = False,
-        disable_headers_validation: bool = False,
+        claims_validation_model: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
+        headers_validation_model: type[JOSEHeader] | None = DefaultHeadersValidationModel,
     ) -> dict[str, Any]:
         """Decode the JWT token with signature verification.
 
@@ -160,11 +141,13 @@ class JWT:
             key (str | bytes | BaseKey): The key instance to verify the JWT signature.
             algorithm (Algorithm): The algorithm to use for verifying the JWT.
             with_detached_payload (JWTClaims | dict[str, Any] | None, opt.):
-                Detached payload to use for verification, if any.
-            disable_claims_validation (bool, opt.): If True, disables claims validation.
-                Signature verification is still performed.
-            disable_headers_validation (bool, opt.): If True, disables headers validation.
-                Signature verification is still performed.
+                Detached payload to use for signature verification, if any.
+            claims_validation_model (type[JWTBaseModel] | None, opt.): the pydantic model
+                to use for claims validation. If None, claims validation is disabled.
+                Default to DefaultClaimsValidationModel.
+            headers_validation_model (type[JOSEHeader] | None, opt.): the pydantic model
+                to use for headers validation. If None, headers validation is disabled.
+                Default to DefaultHeadersValidationModel.
 
         Returns:
             dict[str, Any]: The decoded and verified JWT claims as a dictionary.
@@ -172,36 +155,38 @@ class JWT:
 
         # reset session
         self.reset_token()
+        self.jws = JWS(algorithm)
 
         # prepare key
         if not isinstance(key, BaseKey):
             key = make_key(algorithm, key)
 
-        # prepare detached claims
-        detached_claims = None
         if with_detached_payload is not None:
+            # prepare and validate detached claims
             detached_claims = self.prepare_claims(
-                with_detached_payload, disable_claims_validation
+                with_detached_payload, validation_model=claims_validation_model
             )
-
-        # decode from JWS
-        self.jws = JWS(algorithm)
-        if detached_claims is not None:
+            # JWS decode with detached payload
             self.jws.enable_detached_payload()
-        self.jws.decode(
-            token,
-            key,
-            with_detached_payload=detached_claims,
-            disable_headers_validation=disable_headers_validation,
-        )
-
-        # validate claims
-        try:
-            self.JWTEffectiveClaims(**self.jws.token.validated.decoded.payload)
-        except ValidationError as e:
-            if not disable_claims_validation:
-                raise ClaimsValidationError(validation_errors=e.errors()) from e
-            logger.info(f"Validation error during decoding: {e}")
+            self.jws.decode(
+                token,
+                key,
+                with_detached_payload=detached_claims,
+                headers_validation_model=headers_validation_model,
+            )
+            self.jws.token.validated.model.claims = detached_claims
+        else:
+            # JWS decode without detached payload
+            self.jws.decode(
+                token,
+                key,
+                headers_validation_model=headers_validation_model,
+            )
+            # validate claims
+            self.jws.token.validated.model.claims = self.prepare_claims(
+                self.jws.token.validated.decoded.payload,
+                validation_model=claims_validation_model,
+            )
 
         self.token = self.jws.token.validated
         return self.token.decoded.payload
@@ -229,7 +214,7 @@ class JWT:
         if has_detached_payload:
             self.jws.enable_detached_payload()
         self.jws._allow_none_algorithm = True
-        self.jws.decode(token=token, key=NoneKey(), disable_headers_validation=True)
+        self.jws.decode(token=token, key=NoneKey(), headers_validation_model=None)
         self.jws._allow_none_algorithm = False
 
         self.token = self.jws.token.unsafe

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,5 +1,5 @@
 import pytest
-from superjwt.definitions import JOSEHeader
+from superjwt.definitions import DefaultHeadersValidationModel, JOSEHeader
 from superjwt.exceptions import InvalidHeaderError, JWTError
 from superjwt.jws import JWS
 from superjwt.keys import OctetKey
@@ -20,14 +20,23 @@ def test_not_reset_jws_instance(
     )
 
     key = OctetKey.import_key(secret_key)
-    jws_HS256.encode(header=JOSEHeader(alg="HS256"), payload=claims_fixed_dt, key=key)
+    jws_HS256.encode(
+        header=JOSEHeader(alg="HS256"),
+        payload=claims_fixed_dt,
+        key=key,
+        headers_validation_model=DefaultHeadersValidationModel,
+    )
 
     # not reset JWS instance
     with pytest.raises(JWTError):
-        jws_HS256.decode(token=compact, key=key)
+        jws_HS256.decode(
+            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+        )
 
     jws_HS256.reset()
-    decoded_claims_after_reset = jws_HS256.decode(token=compact, key=key)
+    decoded_claims_after_reset = jws_HS256.decode(
+        token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+    )
     assert decoded_claims_after_reset.decoded.payload == claims_fixed_dt.to_dict()
 
 
@@ -43,7 +52,9 @@ def test_jws_hmac_decoding(jws_HS256: JWS, claims_fixed_dt, secret_key: str):
 
     key = OctetKey.import_key(secret_key)
     decoded_claims = JWTCustomClaims(
-        **jws_HS256.decode(token=compact, key=key).decoded.payload
+        **jws_HS256.decode(
+            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+        ).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()
 
@@ -63,25 +74,34 @@ def test_wrong_header_algorithm(
     headers = JOSEHeader(alg="HS256")
     headers.alg = "ABCDEF"  # wrong algorithm in header  # type: ignore
     invalid_compact = jws_HS256.encode(
-        header=headers, payload=claims_fixed_dt, key=key
+        header=headers, payload=claims_fixed_dt, key=key, headers_validation_model=None
     ).decode("utf-8")
 
     # not reset JWS instance
     with pytest.raises(JWTError):
-        jws_HS256.decode(token=invalid_compact, key=key)
+        jws_HS256.decode(
+            token=invalid_compact,
+            key=key,
+            headers_validation_model=DefaultHeadersValidationModel,
+        )
 
     jws_HS256.reset()
     with pytest.raises(InvalidHeaderError):
-        jws_HS256.decode(token=invalid_compact, key=key)
-
+        jws_HS256.decode(
+            token=invalid_compact,
+            key=key,
+            headers_validation_model=DefaultHeadersValidationModel,
+        )
     jws_HS256.reset()
     jws_token = jws_HS256.decode(
-        token=invalid_compact, key=key, disable_headers_validation=True
+        token=invalid_compact, key=key, headers_validation_model=None
     )
     assert jws_token.decoded.header["alg"] == headers.alg
 
     jws_HS256.reset()
     decoded_claims = JWTCustomClaims(
-        **jws_HS256.decode(token=compact, key=key).decoded.payload
+        **jws_HS256.decode(
+            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+        ).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -136,6 +136,23 @@ def test_encode_decode_pydantic_claims(
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=claims, key=secret_key)
 
+    # test custom claims model validation
+    claims = JWTCustomClaims(**claims_dict)
+    # encoding valid
+    token = jwt.encode(claims=claims, key=secret_key)
+    jws_token = jwt.jws.token.validated
+    jwt.encode(claims=claims, key=secret_key, claims_validation_model=JWTCustomClaims)
+    jws_token2 = jwt.jws.token.validated
+    assert jws_token.encoded.compact == jws_token2.encoded.compact
+    # decoding
+    claims.user_id = None  # invalid type for user_id  # type: ignore
+    token = jwt.encode(claims=claims, key=secret_key, claims_validation_model=None)
+    # passes (validation with default JWTClaims)
+    jwt.decode(token=token, key=secret_key)
+    # fails (validation with JWTCustomClaims)
+    with pytest.raises(ClaimsValidationError):
+        jwt.decode(token=token, key=secret_key, claims_validation_model=JWTCustomClaims)
+
 
 def test_decode_invalid_signature(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     wrong_key = "wrongkey_but_long_enough"
@@ -168,12 +185,12 @@ def test_encode_decode_claims_validation_disabled(
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=unvalidated_claims, key=secret_key_random)
     encoded = jwt.encode(
-        unvalidated_claims, secret_key_random, disable_claims_validation=True
+        unvalidated_claims, secret_key_random, claims_validation_model=None
     )
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key_random)
     decoded = jwt.decode(
-        token=encoded, key=secret_key_random, disable_claims_validation=True
+        token=encoded, key=secret_key_random, claims_validation_model=None
     )
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
@@ -194,13 +211,13 @@ def test_encode_decode_claims_dict_validation_disabled(
         jwt.encode(claims=unvalidated_claims_dict, key=secret_key_random)
     # run encoding again with validation disabled, does not raise error
     encoded = jwt.encode(
-        unvalidated_claims_dict, secret_key_random, disable_claims_validation=True
+        unvalidated_claims_dict, secret_key_random, claims_validation_model=None
     )
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key_random)
     # run decoding again with validation disabled, does not raise error
     decoded = jwt.decode(
-        token=encoded, key=secret_key_random, disable_claims_validation=True
+        token=encoded, key=secret_key_random, claims_validation_model=None
     )
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
@@ -216,10 +233,10 @@ def test_required_field_missing(jwt: JWT, claims: JWTCustomClaims, secret_key: s
     claims.sub = None  # remove required field 'sub'  # type: ignore
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=claims, key=secret_key)
-    encoded = jwt.encode(claims, secret_key, disable_claims_validation=True)
+    encoded = jwt.encode(claims, secret_key, claims_validation_model=None)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key)
-    decoded = jwt.decode(token=encoded, key=secret_key, disable_claims_validation=True)
+        jwt.decode(token=encoded, key=secret_key, claims_validation_model=JWTCustomClaims)
+    decoded = jwt.decode(token=encoded, key=secret_key, claims_validation_model=None)
     with pytest.raises(pydantic.ValidationError):
         JWTCustomClaims(**decoded)
 


### PR DESCRIPTION
Refactoring of all the validation logic for claims and headers.
- both `encode()` and `decode()` have now `claims_validation_model` and `headers_validation_model` parameters. When a user wants to validate data, these behaviors will occur:
  - `decode()`: optional. Will default to `JWTClaims` (claims) / `JOSEHeader` (headers) if not set. Can be overridden with any custom pydantic model.
  - `encode()` with a dict: optional. Will default to `JWTClaims` (claims) / `JOSEHeader` (headers) if not set. Can be overridden with any custom pydantic model.
  - `encode()` with a pydantic model: optional. Will default to the actual pydantic model used for data encoding. Can be overridden with any custom pydantic model.
  - set the parameters to `None` to disable any validation. Default is set to `JWTClaims` / `JOSEHeader`.
  - `JWT.JWTEffectiveClaims` has been removed
- claims validation happens in `JWT` whereas headers validation happens in `JWS`