### PR TITLE
refactor: rename validation_xxx params

### DIFF
--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -60,7 +60,7 @@ class JWS:
         headers: JOSEHeader,
         payload: JWTBaseModel,
         key: BaseKey,
-        headers_validation_model: type[JOSEHeader] | None,
+        validation_headers: type[JOSEHeader] | None,
     ) -> bytes:
         if self.token.validated.encoded.compact != b"..":
             raise JWTError("JWS instance data must be reset")
@@ -69,7 +69,7 @@ class JWS:
         headers = self.prepare_headers(
             headers,
             cast("Algorithm", self.algorithm.name),
-            validation_model=headers_validation_model,
+            validation_model=validation_headers,
         )
         self.token.validated.model.headers = headers
 
@@ -94,7 +94,7 @@ class JWS:
         key: BaseKey,
         *,
         with_detached_payload: JWTBaseModel | None = None,
-        headers_validation_model: type[JOSEHeader] | None,
+        validation_headers: type[JOSEHeader] | None,
     ) -> JWSToken:
         if (
             self.token.validated.encoded.compact != b".."
@@ -109,7 +109,7 @@ class JWS:
         self.validate_headers(
             self.token.unsafe.decoded.headers,
             cast("Algorithm", self.algorithm.name),
-            validation_model=headers_validation_model,
+            validation_model=validation_headers,
         )
 
         # verify signature

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -40,9 +40,9 @@ class JWT:
         key: str | bytes | BaseKey,
         algorithm: Algorithm = "HS256",
         *,
-        claims_validation_model: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
         headers: JOSEHeader | dict[str, Any] | None = None,
-        headers_validation_model: type[JOSEHeader] | None = DefaultHeadersValidationModel,
+        validation_claims: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
+        validation_headers: type[JOSEHeader] | None = DefaultHeadersValidationModel,
     ) -> bytes:
         """Encode and sign the claims as a JWT token
 
@@ -51,14 +51,14 @@ class JWT:
             key (str | bytes | BaseKey): The key instance to sign the JWT with.
             algorithm (Algorithm): The algorithm to use for signing the JWT.
                 Will default to 'HS256' (HMAC with SHA-256).
-            claims_validation_model (type[JWTBaseModel] | None, opt.): the pydantic model
-                to use for claims validation. If None, claims validation is disabled.
-                Default to DefaultClaimsValidationModel.
             headers (JOSEHeader | dict[str, Any] | None, opt.): Custom JWS headers to include
                 in the JWT. Will use default JWS headers if not provided.
-            headers_validation_model (type[JOSEHeader] | None, opt.): the pydantic model
+            validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
+                to use for claims validation. If None, claims validation is disabled.
+                Default to DefaultClaimsValidationModel or claims.__class__ if pydantic object.
+            validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
-                Default to DefaultHeadersValidationModel.
+                Default to DefaultHeadersValidationModel or headers.__class__ if pydantic object.
 
         Returns:
             bytes: the encoded compact JWT token
@@ -68,7 +68,7 @@ class JWT:
         self.reset_token()
 
         # prepare claims data and perform validation
-        claims = self.prepare_claims(claims, validation_model=claims_validation_model)
+        claims = self.prepare_claims(claims, validation_model=validation_claims)
 
         # prepare headers data (validation will be done later in JWS instance)
         headers = JWS.prepare_headers(headers, algorithm, validation_model=None)
@@ -83,7 +83,7 @@ class JWT:
             headers=headers,
             payload=claims,
             key=key,
-            headers_validation_model=headers_validation_model,
+            validation_headers=validation_headers,
         )
         self.jws.token.validated.model.claims = claims
 
@@ -131,8 +131,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         with_detached_payload: JWTClaims | dict[str, Any] | None = None,
-        claims_validation_model: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
-        headers_validation_model: type[JOSEHeader] | None = DefaultHeadersValidationModel,
+        validation_claims: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
+        validation_headers: type[JOSEHeader] | None = DefaultHeadersValidationModel,
     ) -> dict[str, Any]:
         """Decode the JWT token with signature verification.
 
@@ -142,10 +142,10 @@ class JWT:
             algorithm (Algorithm): The algorithm to use for verifying the JWT.
             with_detached_payload (JWTClaims | dict[str, Any] | None, opt.):
                 Detached payload to use for signature verification, if any.
-            claims_validation_model (type[JWTBaseModel] | None, opt.): the pydantic model
+            validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
                 Default to DefaultClaimsValidationModel.
-            headers_validation_model (type[JOSEHeader] | None, opt.): the pydantic model
+            validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
                 Default to DefaultHeadersValidationModel.
 
@@ -164,7 +164,7 @@ class JWT:
         if with_detached_payload is not None:
             # prepare and validate detached claims
             detached_claims = self.prepare_claims(
-                with_detached_payload, validation_model=claims_validation_model
+                with_detached_payload, validation_model=validation_claims
             )
             # JWS decode with detached payload
             self.jws.enable_detached_payload()
@@ -172,7 +172,7 @@ class JWT:
                 token,
                 key,
                 with_detached_payload=detached_claims,
-                headers_validation_model=headers_validation_model,
+                validation_headers=validation_headers,
             )
             self.jws.token.validated.model.claims = detached_claims
         else:
@@ -180,12 +180,12 @@ class JWT:
             self.jws.decode(
                 token,
                 key,
-                headers_validation_model=headers_validation_model,
+                validation_headers=validation_headers,
             )
             # validate claims
             self.jws.token.validated.model.claims = self.prepare_claims(
                 self.jws.token.validated.decoded.payload,
-                validation_model=claims_validation_model,
+                validation_model=validation_claims,
             )
 
         self.token = self.jws.token.validated
@@ -214,7 +214,7 @@ class JWT:
         if has_detached_payload:
             self.jws.enable_detached_payload()
         self.jws._allow_none_algorithm = True
-        self.jws.decode(token=token, key=NoneKey(), headers_validation_model=None)
+        self.jws.decode(token=token, key=NoneKey(), validation_headers=None)
         self.jws._allow_none_algorithm = False
 
         self.token = self.jws.token.unsafe

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -24,18 +24,18 @@ def test_not_reset_jws_instance(
         headers=JOSEHeader(alg="HS256"),
         payload=claims_fixed_dt,
         key=key,
-        headers_validation_model=DefaultHeadersValidationModel,
+        validation_headers=DefaultHeadersValidationModel,
     )
 
     # not reset JWS instance
     with pytest.raises(JWTError):
         jws_HS256.decode(
-            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
         )
 
     jws_HS256.reset()
     decoded_claims_after_reset = jws_HS256.decode(
-        token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+        token=compact, key=key, validation_headers=DefaultHeadersValidationModel
     )
     assert decoded_claims_after_reset.decoded.payload == claims_fixed_dt.to_dict()
 
@@ -53,7 +53,7 @@ def test_jws_hmac_decoding(jws_HS256: JWS, claims_fixed_dt, secret_key: str):
     key = OctKey.import_key(secret_key)
     decoded_claims = JWTCustomClaims(
         **jws_HS256.decode(
-            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
         ).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()
@@ -74,7 +74,7 @@ def test_wrong_header_algorithm(
     headers = JOSEHeader(alg="HS256")
     headers.alg = "ABCDEF"  # wrong algorithm in header  # type: ignore
     invalid_compact = jws_HS256.encode(
-        headers=headers, payload=claims_fixed_dt, key=key, headers_validation_model=None
+        headers=headers, payload=claims_fixed_dt, key=key, validation_headers=None
     ).decode("utf-8")
 
     # not reset JWS instance
@@ -82,7 +82,7 @@ def test_wrong_header_algorithm(
         jws_HS256.decode(
             token=invalid_compact,
             key=key,
-            headers_validation_model=DefaultHeadersValidationModel,
+            validation_headers=DefaultHeadersValidationModel,
         )
 
     jws_HS256.reset()
@@ -90,18 +90,16 @@ def test_wrong_header_algorithm(
         jws_HS256.decode(
             token=invalid_compact,
             key=key,
-            headers_validation_model=DefaultHeadersValidationModel,
+            validation_headers=DefaultHeadersValidationModel,
         )
     jws_HS256.reset()
-    jws_token = jws_HS256.decode(
-        token=invalid_compact, key=key, headers_validation_model=None
-    )
+    jws_token = jws_HS256.decode(token=invalid_compact, key=key, validation_headers=None)
     assert jws_token.decoded.headers["alg"] == headers.alg
 
     jws_HS256.reset()
     decoded_claims = JWTCustomClaims(
         **jws_HS256.decode(
-            token=compact, key=key, headers_validation_model=DefaultHeadersValidationModel
+            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
         ).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -142,17 +142,17 @@ def test_encode_decode_pydantic_claims(
     # encoding valid
     token = jwt.encode(claims=claims, key=secret_key)
     jws_token = jwt.jws.token.validated
-    jwt.encode(claims=claims, key=secret_key, claims_validation_model=JWTCustomClaims)
+    jwt.encode(claims=claims, key=secret_key, validation_claims=JWTCustomClaims)
     jws_token2 = jwt.jws.token.validated
     assert jws_token.encoded.compact == jws_token2.encoded.compact
     # decoding
     claims.user_id = None  # invalid type for user_id  # type: ignore
-    token = jwt.encode(claims=claims, key=secret_key, claims_validation_model=None)
+    token = jwt.encode(claims=claims, key=secret_key, validation_claims=None)
     # passes (validation with default JWTClaims)
     jwt.decode(token=token, key=secret_key)
     # fails (validation with JWTCustomClaims)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=token, key=secret_key, claims_validation_model=JWTCustomClaims)
+        jwt.decode(token=token, key=secret_key, validation_claims=JWTCustomClaims)
 
 
 def test_decode_invalid_signature(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
@@ -185,14 +185,10 @@ def test_encode_decode_claims_validation_disabled(
     unvalidated_claims.sub = 1  # invalid type for sub  # type: ignore
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=unvalidated_claims, key=secret_key_random)
-    encoded = jwt.encode(
-        unvalidated_claims, secret_key_random, claims_validation_model=None
-    )
+    encoded = jwt.encode(unvalidated_claims, secret_key_random, validation_claims=None)
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key_random)
-    decoded = jwt.decode(
-        token=encoded, key=secret_key_random, claims_validation_model=None
-    )
+    decoded = jwt.decode(token=encoded, key=secret_key_random, validation_claims=None)
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
     decoded_claims.sub = claims.sub  # fix type for sub to match original claims
@@ -212,14 +208,12 @@ def test_encode_decode_claims_dict_validation_disabled(
         jwt.encode(claims=unvalidated_claims_dict, key=secret_key_random)
     # run encoding again with validation disabled, does not raise error
     encoded = jwt.encode(
-        unvalidated_claims_dict, secret_key_random, claims_validation_model=None
+        unvalidated_claims_dict, secret_key_random, validation_claims=None
     )
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key_random)
     # run decoding again with validation disabled, does not raise error
-    decoded = jwt.decode(
-        token=encoded, key=secret_key_random, claims_validation_model=None
-    )
+    decoded = jwt.decode(token=encoded, key=secret_key_random, validation_claims=None)
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
     decoded_claims.sub = claims_dict["sub"]  # fix type for sub to match original claims
@@ -234,10 +228,10 @@ def test_required_field_missing(jwt: JWT, claims: JWTCustomClaims, secret_key: s
     claims.sub = None  # remove required field 'sub'  # type: ignore
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=claims, key=secret_key)
-    encoded = jwt.encode(claims, secret_key, claims_validation_model=None)
+    encoded = jwt.encode(claims, secret_key, validation_claims=None)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key, claims_validation_model=JWTCustomClaims)
-    decoded = jwt.decode(token=encoded, key=secret_key, claims_validation_model=None)
+        jwt.decode(token=encoded, key=secret_key, validation_claims=JWTCustomClaims)
+    decoded = jwt.decode(token=encoded, key=secret_key, validation_claims=None)
     with pytest.raises(pydantic.ValidationError):
         JWTCustomClaims(**decoded)
 
@@ -368,10 +362,10 @@ def test_detached_payload_no_jws_instance(jwt: JWT):
 
 def test_expired_token(jwt: JWT, secret_key: str):
     claims = JWTClaims.model_construct(exp=datetime.now(UTC) - timedelta(days=1))
-    token = jwt.encode(claims=claims, key=secret_key, claims_validation_model=None)
+    token = jwt.encode(claims=claims, key=secret_key, validation_claims=None)
     with pytest.raises(TokenExpiredError):
         jwt.encode(claims=claims, key=secret_key)
-    decoded = jwt.decode(token=token, key=secret_key, claims_validation_model=None)
+    decoded = jwt.decode(token=token, key=secret_key, validation_claims=None)
     assert decoded["exp"] == claims.to_dict()["exp"]
     with pytest.raises(TokenExpiredError):
         jwt.decode(token=token, key=secret_key)


### PR DESCRIPTION
- rename `headers_validation_model` to `validation_headers`
- rename `claims_validation_model` to `validation_claims`