### PR TITLE
refactor: improve validation and underlying structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
     - defaulting with no `'iat'` set
     - `with_issued_at()` method added
     - modular model with reusable mixins
-- Refactoring of claims and headers validation ([#21])
-    - `encode()` and `decode()` have now the same validation behavior with `validation_claims` and `validation_headers` parameters. Disable it by setting to `None`
+- Refactoring of claims and headers validation ([#21]) ([#30])
+    - `encode()` and `decode()` have now the same validation behavior with `validation_claims` (default to `JWTClaims`) and `validation_headers` (default to `JOSEHeader`) parameters. Disable it by setting to `None`
+    - claims data sent as dict are no longer serialized with Pydantic (datetime object will no longer work). Usage of Pydantic models is recommended instead.
 
 ## v0.2.0 (2025-12-27)
 
@@ -48,6 +49,7 @@
 
 :tada: superjwt repository initialization
 
+[#30]: /../../issues/30
 [#24]: /../../issues/24
 [#21]: /../../issues/21
 [#17]: /../../issues/17

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -28,7 +28,6 @@ from superjwt.exceptions import (
     AlgorithmNotSupportedError,
     InvalidAlgorithmError,
     InvalidHeaderError,
-    JWTError,
     TokenExpiredError,
 )
 from superjwt.keys import BaseKey, NoneKey, OctKey
@@ -91,6 +90,8 @@ class JWTBaseModel(BaseModel):
 
 
 class JOSEHeader(JWTBaseModel):
+    _strict_crit_check: bool = False
+
     alg: Annotated[
         Algorithm | Literal["none"],
         Field(description="algorithm - the algorithm used to sign the JWT"),
@@ -125,7 +126,6 @@ class JOSEHeader(JWTBaseModel):
         if value is None:
             return value
 
-        crit_headers_strict_check: bool = info.context  # type: ignore
         if value is not None and len(value) == 0:  # empty list is forbidden
             raise ValueError("'crit' header must be a non-empty list of strings")
 
@@ -136,7 +136,7 @@ class JOSEHeader(JWTBaseModel):
             if el not in info.data.keys():
                 missing.append(el)
             # check for unsupported custom headers
-            elif crit_headers_strict_check and (el not in cls.model_fields.keys()):
+            elif cls._strict_crit_check and (el not in cls.model_fields.keys()):
                 unsupported.append(el)
         if missing:
             raise ValueError(f"Missing crit headers: {', '.join(missing)}")
@@ -352,54 +352,36 @@ def make_key(algorithm: Algorithm | Literal["none"], key: str | bytes) -> BaseKe
     return key_type.import_key(key)
 
 
-DefaultClaimsValidationModel = JWTClaims
-DefaultHeadersValidationModel = JOSEHeader
-
-
-def select_effective_validation_model(
-    data: JWTBaseModel | dict[str, Any] | None,
+def get_effective_data_model(
+    data: JWTBaseModel | dict[str, Any],
     validation_model: type[JWTBaseModel] | None,
-    DefaultValidationModel: type[JWTBaseModel],
 ) -> type[JWTBaseModel]:
-    # 1. case validation disabled
-    if validation_model is None:
-        return DefaultValidationModel
-    # 2. default case
-    elif validation_model is DefaultValidationModel:
-        # override with self model if data is a pydantic model
-        if isinstance(data, JWTBaseModel):
-            return data.__class__
-        else:
-            return DefaultValidationModel
-    # 3. custom validation model was provided, overrides default
-    elif issubclass(validation_model, JWTBaseModel):
+    if isinstance(data, JWTBaseModel):
+        return type(data)
+    if validation_model is not None:
         return validation_model
-    raise JWTError("Invalid validation model type")
+    return JWTBaseModel
 
 
-def prepare_and_validate_model(
-    data: JWTBaseModel | dict[str, Any] | None,
-    EffectiveValidationModel: type[JWTBaseModel],
+def prepare_and_validate_data(
+    data: JWTBaseModel | dict[str, Any],
+    validation_model: type[JWTBaseModel] | None,
+    *,
     type_err_msg: str = "Wrong data type for pydantic model preparation",
-    default_value: dict[str, Any] = {},  # noqa: B006
-    disable_validation: bool = False,
-) -> JWTBaseModel:
-    # prepare data dict
-    # 1 . case data is None
-    if data is None:
-        data_dict = default_value
-    # 2. case data is a dict
-    elif isinstance(data, dict):
+) -> dict[str, Any]:
+    # 1. Prepare data as dict for pydantic validation
+    # --> case data is a dict
+    if isinstance(data, dict):
         data_dict = data.copy()
-    # 3. case data is a pydantic model
-    elif isinstance(data, JWTBaseModel):
-        data_dict = data.to_dict()
+    # --> case data is a pydantic model
+    elif isinstance(data, BaseModel):
+        data_dict = data.model_dump(exclude_none=True)
     else:
         raise TypeError(type_err_msg)
 
-    # RETURN PYDANTIC MODEL WITH NO VALIDATION
-    if disable_validation:
-        return EffectiveValidationModel.model_construct(**data_dict)
+    # 2. Validate data
+    if validation_model is not None:
+        validation_model(**data_dict)  # run validation
 
-    # RETURN PYDANTIC MODEL WITH VALIDATION RUN
-    return EffectiveValidationModel(**data_dict)
+    # 3. Return data as dict
+    return data_dict

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -7,14 +7,13 @@ from superjwt.algorithms import BaseJWSAlgorithm, NoneAlgorithm
 from superjwt.definitions import (
     MAX_TOKEN_LENGTH,
     Algorithm,
-    DefaultHeadersValidationModel,
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
     JWTBaseModel,
+    get_effective_data_model,
     get_jws_algorithm,
-    prepare_and_validate_model,
-    select_effective_validation_model,
+    prepare_and_validate_data,
 )
 from superjwt.exceptions import (
     HeaderValidationError,
@@ -33,7 +32,6 @@ class JWS:
         self,
         algorithm: Algorithm | Literal["none"],
         max_token_size: int = MAX_TOKEN_LENGTH,
-        crit_headers_strict_check: bool = False,
     ):
         self.token: JWSTokenLifeCycle = JWSTokenLifeCycle()
         self.algorithm: BaseJWSAlgorithm[BaseKey] = get_jws_algorithm(algorithm)
@@ -42,7 +40,6 @@ class JWS:
 
         self.raw_jws: bytes = b""
         self.max_size = max_token_size
-        self.crit_headers_strict_check = crit_headers_strict_check
         self._allow_none_algorithm = False
 
     def reset(self) -> None:
@@ -57,35 +54,49 @@ class JWS:
 
     def encode(
         self,
-        headers: JOSEHeader,
-        payload: JWTBaseModel,
+        headers: JOSEHeader | dict[str, Any] | None,
+        payload: dict[str, Any],
         key: BaseKey,
-        validation_headers: type[JOSEHeader] | None,
+        *,
+        validation_headers: type[JOSEHeader] | None = JOSEHeader,
     ) -> bytes:
         if self.token.validated.encoded.compact != b"..":
             raise JWTError("JWS instance data must be reset")
 
-        # check headers is valid
-        headers = self.prepare_headers(
-            headers,
-            cast("Algorithm", self.algorithm.name),
-            validation_model=validation_headers,
+        # prepare headers data and perform validation
+        if headers is None:
+            headers = JOSEHeader.make_default(cast("Algorithm", self.algorithm.name))
+
+        try:
+            headers_dict = prepare_and_validate_data(
+                data=headers,
+                validation_model=validation_headers,
+                type_err_msg="headers must be a JOSEHeader instance or a dict",
+            )
+        except ValidationError as e:
+            raise HeaderValidationError(validation_errors=e.errors()) from e
+
+        # set headers data
+        default_headers_model = get_effective_data_model(headers, validation_headers)
+        self.token.validated.model.headers = cast(
+            "JOSEHeader", default_headers_model.model_construct(**headers_dict)
         )
-        self.token.validated.model.headers = headers
-
-        headers_dict = headers.to_dict()
-        encoded_headers = json.dumps(headers_dict, separators=(",", ":")).encode("utf-8")
         self.token.validated.decoded.headers = headers_dict
-        self.token.validated.encoded.headers = urlsafe_b64encode(encoded_headers)
+        self.token.validated.encoded.headers = urlsafe_b64encode(
+            json.dumps(headers_dict, separators=(",", ":")).encode("utf-8")
+        )
 
-        payload_dict = payload.to_dict()
-        encoded_payload = json.dumps(payload_dict, separators=(",", ":")).encode("utf-8")
-        self.token.validated.decoded.payload = payload_dict
-        self.token.validated.encoded.payload = urlsafe_b64encode(encoded_payload)
+        # set payload data
+        self.token.validated.decoded.payload = payload
+        self.token.validated.encoded.payload = urlsafe_b64encode(
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        )
 
+        # set signature data
         signature = self.algorithm.sign(self.token.validated.encoded.signing_input, key)
         self.token.validated.decoded.signature = SecretBytes(signature)
         self.token.validated.encoded.signature = SecretBytes(urlsafe_b64encode(signature))
+
         return self.token.validated.encoded.compact
 
     def decode(
@@ -93,8 +104,8 @@ class JWS:
         token: str | bytes,
         key: BaseKey,
         *,
-        with_detached_payload: JWTBaseModel | None = None,
-        validation_headers: type[JOSEHeader] | None,
+        with_detached_payload: dict[str, Any] | None = None,
+        validation_headers: type[JOSEHeader] | None = JOSEHeader,
     ) -> JWSToken:
         if (
             self.token.validated.encoded.compact != b".."
@@ -105,19 +116,15 @@ class JWS:
         # decode JWT token parts
         self.decode_parts(token, with_detached_payload)
 
-        # validate headers
-        self.validate_headers(
-            self.token.unsafe.decoded.headers,
-            cast("Algorithm", self.algorithm.name),
-            validation_model=validation_headers,
-        )
+        # validate headers and algorithm
+        self.validate_headers_and_algorithm(validation_headers)
 
         # verify signature
         self.verify_signature(key)
         return self.token.validated
 
     def decode_parts(
-        self, token: str | bytes, detached_payload: JWTBaseModel | None = None
+        self, token: str | bytes, detached_payload: dict[str, Any] | None = None
     ) -> None:
         if len(token) > self.max_size:
             raise SizeExceededError(
@@ -135,17 +142,13 @@ class JWS:
         # decode payload
         if self.has_detached_payload:
             if detached_payload is None:
-                payload_dict = {}
-                encoded_payload = b""
+                self.token.unsafe.decoded.payload = {}
+                self.token.unsafe.encoded.payload = urlsafe_b64encode(b"")
             else:
-                payload_dict: dict[str, Any] = detached_payload.model_dump(
-                    exclude_none=True
+                self.token.unsafe.decoded.payload = detached_payload
+                self.token.unsafe.encoded.payload = urlsafe_b64encode(
+                    json.dumps(detached_payload, separators=(",", ":")).encode("utf-8")
                 )
-                encoded_payload = json.dumps(payload_dict, separators=(",", ":")).encode(
-                    "utf-8"
-                )
-            self.token.unsafe.decoded.payload = payload_dict
-            self.token.unsafe.encoded.payload = urlsafe_b64encode(encoded_payload)
         else:
             self.decode_raw_payload()
 
@@ -214,54 +217,34 @@ class JWS:
             )
         )
 
-    @staticmethod
-    def prepare_headers(
-        headers: JOSEHeader | dict[str, Any] | None,
-        algorithm: Algorithm,
+    def validate_headers_and_algorithm(
+        self,
         validation_model: type[JWTBaseModel] | None,
-    ) -> JOSEHeader:
-        EffectiveValidationModel = select_effective_validation_model(
-            headers,
-            validation_model,
-            DefaultHeadersValidationModel,
-        )
+    ) -> None:
+        headers_dict = self.token.unsafe.decoded.headers
 
+        # validate headers
         try:
-            return cast(
-                "JOSEHeader",
-                prepare_and_validate_model(
-                    data=headers,
-                    EffectiveValidationModel=EffectiveValidationModel,
-                    type_err_msg="headers must be a JOSEHeader instance or a dict",
-                    default_value=JOSEHeader.make_default(algorithm).to_dict(),
-                    disable_validation=validation_model is None,
-                ),
+            prepare_and_validate_data(
+                data=headers_dict,
+                validation_model=validation_model,
             )
         except ValidationError as e:
             raise HeaderValidationError(validation_errors=e.errors()) from e
 
-    def validate_headers(
-        self,
-        headers: dict[str, Any],
-        algorithm: Algorithm,
-        validation_model: type[JOSEHeader] | None,
-    ) -> None:
-        headers_validated = self.prepare_headers(
-            headers=headers,
-            algorithm=algorithm,
-            validation_model=validation_model,
-        )
-        headers_validated = headers_validated.model_validate(
-            headers_validated, context=self.crit_headers_strict_check
+        # set headers model data
+        headers_dict = self.token.unsafe.decoded.headers
+        default_headers_model = get_effective_data_model(headers_dict, validation_model)
+        self.token.unsafe.model.headers = headers_validated = cast(
+            "JOSEHeader", default_headers_model.model_construct(**headers_dict)
         )
 
-        self.token.unsafe.model.headers = headers_validated
-
-        if validation_model is not None:
-            if headers_validated.alg != self.algorithm.name:
-                raise InvalidHeaderError(
-                    f"JWS algorithm '{headers_validated.alg}' does not match expected '{self.algorithm.name}'"
-                )
+        # check algorithm match
+        pass_through = self.algorithm.name == "none" and self._allow_none_algorithm
+        if not pass_through and headers_validated.alg != self.algorithm.name:
+            raise InvalidHeaderError(
+                f"JWS algorithm '{headers_validated.alg}' does not match expected '{self.algorithm.name}'"
+            )
 
     def verify_signature(self, key: BaseKey) -> bool:
         if isinstance(self.algorithm, NoneAlgorithm) and not self._allow_none_algorithm:

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -5,15 +5,13 @@ from pydantic import ValidationError
 
 from superjwt.definitions import (
     Algorithm,
-    DefaultClaimsValidationModel,
-    DefaultHeadersValidationModel,
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
     JWTClaims,
+    get_effective_data_model,
     make_key,
-    prepare_and_validate_model,
-    select_effective_validation_model,
+    prepare_and_validate_data,
 )
 from superjwt.exceptions import (
     ClaimsValidationError,
@@ -41,8 +39,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
-        validation_headers: type[JOSEHeader] | None = DefaultHeadersValidationModel,
+        validation_claims: type[JWTBaseModel] | None = JWTClaims,
+        validation_headers: type[JOSEHeader] | None = JOSEHeader,
     ) -> bytes:
         """Encode and sign the claims as a JWT token
 
@@ -55,10 +53,10 @@ class JWT:
                 in the JWT. Will use default JWS headers if not provided.
             validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
-                Default to DefaultClaimsValidationModel or claims.__class__ if pydantic object.
+                Defaults to JWTClaims. (standard RFC 7519 registered claims)
             validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
-                Default to DefaultHeadersValidationModel or headers.__class__ if pydantic object.
+                Defaults to JOSEHeader. (standard JOSE Header)
 
         Returns:
             bytes: the encoded compact JWT token
@@ -68,10 +66,16 @@ class JWT:
         self.reset_token()
 
         # prepare claims data and perform validation
-        claims = self.prepare_claims(claims, validation_model=validation_claims)
-
-        # prepare headers data (validation will be done later in JWS instance)
-        headers = JWS.prepare_headers(headers, algorithm, validation_model=None)
+        if claims is None:
+            claims = JWTBaseModel()
+        try:
+            claims_dict = prepare_and_validate_data(
+                data=claims,
+                validation_model=validation_claims,
+                type_err_msg="claims must be a JWTBaseModel instance or a dict",
+            )
+        except ValidationError as e:
+            raise ClaimsValidationError(validation_errors=e.errors()) from e
 
         # prepare key
         if not isinstance(key, BaseKey):
@@ -81,11 +85,16 @@ class JWT:
         self.jws = JWS(algorithm)
         self.jws.encode(
             headers=headers,
-            payload=claims,
+            payload=claims_dict,
             key=key,
             validation_headers=validation_headers,
         )
-        self.jws.token.validated.model.claims = claims
+
+        # set claims model data
+        default_claims_model = get_effective_data_model(claims, validation_claims)
+        self.jws.token.validated.model.claims = default_claims_model.model_construct(
+            **claims_dict
+        )
 
         self.token = self.jws.token.validated
         return self.token.encoded.compact
@@ -103,27 +112,6 @@ class JWT:
 
         return self.token.encoded.compact
 
-    @staticmethod
-    def prepare_claims(
-        claims: JWTBaseModel | dict[str, Any] | None,
-        validation_model: type[JWTBaseModel] | None,
-    ) -> JWTBaseModel:
-        EffectiveValidationModel = select_effective_validation_model(
-            claims,
-            validation_model,
-            DefaultClaimsValidationModel,
-        )
-
-        try:
-            return prepare_and_validate_model(
-                data=claims,
-                EffectiveValidationModel=EffectiveValidationModel,
-                type_err_msg="claims must be a JWTBaseModel instance or a dict",
-                disable_validation=validation_model is None,
-            )
-        except ValidationError as e:
-            raise ClaimsValidationError(validation_errors=e.errors()) from e
-
     def decode(
         self,
         token: str | bytes,
@@ -131,8 +119,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         with_detached_payload: JWTClaims | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = DefaultClaimsValidationModel,
-        validation_headers: type[JOSEHeader] | None = DefaultHeadersValidationModel,
+        validation_claims: type[JWTBaseModel] | None = JWTClaims,
+        validation_headers: type[JOSEHeader] | None = JOSEHeader,
     ) -> dict[str, Any]:
         """Decode the JWT token with signature verification.
 
@@ -144,10 +132,10 @@ class JWT:
                 Detached payload to use for signature verification, if any.
             validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
-                Default to DefaultClaimsValidationModel.
+                Defaults to JWTClaims. (standard RFC 7519 registered claims)
             validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
-                Default to DefaultHeadersValidationModel.
+                Defaults to JOSEHeader. (standard JOSE Header)
 
         Returns:
             dict[str, Any]: The decoded and verified JWT claims as a dictionary.
@@ -161,31 +149,58 @@ class JWT:
         if not isinstance(key, BaseKey):
             key = make_key(algorithm, key)
 
+        # CASE 1: detached payload mode
         if with_detached_payload is not None:
-            # prepare and validate detached claims
-            detached_claims = self.prepare_claims(
-                with_detached_payload, validation_model=validation_claims
-            )
-            # JWS decode with detached payload
             self.jws.enable_detached_payload()
+
+            # prepare detached claims data and perform validation
+            try:
+                claims_dict = prepare_and_validate_data(
+                    data=with_detached_payload,
+                    validation_model=validation_claims,
+                )
+            except ValidationError as e:
+                raise ClaimsValidationError(validation_errors=e.errors()) from e
+
+            # set claims model data
+            default_claims_model = get_effective_data_model(
+                claims_dict, validation_claims
+            )
+            self.jws.token.unsafe.model.claims = default_claims_model.model_construct(
+                **claims_dict
+            )
+
+            # JWS decode
             self.jws.decode(
                 token,
                 key,
-                with_detached_payload=detached_claims,
+                with_detached_payload=claims_dict,
                 validation_headers=validation_headers,
             )
-            self.jws.token.validated.model.claims = detached_claims
+
+        # CASE 2: normal mode
         else:
-            # JWS decode without detached payload
+            # JWS decode
             self.jws.decode(
                 token,
                 key,
                 validation_headers=validation_headers,
             )
             # validate claims
-            self.jws.token.validated.model.claims = self.prepare_claims(
-                self.jws.token.validated.decoded.payload,
-                validation_model=validation_claims,
+            try:
+                prepare_and_validate_data(
+                    data=self.jws.token.validated.decoded.payload,
+                    validation_model=validation_claims,
+                )
+            except ValidationError as e:
+                raise ClaimsValidationError(validation_errors=e.errors()) from e
+
+            # set claims model data
+            default_claims_model = get_effective_data_model(
+                self.jws.token.validated.decoded.payload, validation_claims
+            )
+            self.jws.token.validated.model.claims = default_claims_model.model_construct(
+                **self.jws.token.validated.decoded.payload
             )
 
         self.token = self.jws.token.validated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,24 +75,24 @@ def iss() -> str:
 
 
 @pytest.fixture
-def iat() -> datetime:
-    return datetime.now(UTC)
+def iat() -> float:
+    return datetime.now(UTC).timestamp()
 
 
 @pytest.fixture
-def nbf(iat: datetime) -> float:
-    return (iat + timedelta(days=30)).timestamp()
+def nbf(iat: float) -> float:
+    return (datetime.fromtimestamp(iat) + timedelta(days=30)).timestamp()
 
 
 @pytest.fixture
-def exp() -> datetime:
-    return datetime.strptime("2042-04-02T00:42:42.123456+0000", "%Y-%m-%dT%H:%M:%S.%f%z")
+def exp() -> float:
+    return datetime.strptime(
+        "2042-04-02T00:42:42.123456+0000", "%Y-%m-%dT%H:%M:%S.%f%z"
+    ).timestamp()
 
 
 @pytest.fixture
-def claims_dict(
-    sub: str, iss: str, iat: datetime, nbf: float, exp: datetime
-) -> dict[str, Any]:
+def claims_dict(sub: str, iss: str, iat: float, nbf: float, exp: float) -> dict[str, Any]:
     return {
         "iss": iss,
         "sub": sub,
@@ -100,8 +100,8 @@ def claims_dict(
         "nbf": nbf,
         "exp": exp,
         "user_id": "value",
-        "past_date": (iat - timedelta(days=1)).timestamp(),
-        "future_date": (exp + timedelta(days=1)).timestamp(),
+        "past_date": (datetime.fromtimestamp(iat) - timedelta(days=1)).timestamp(),
+        "future_date": (datetime.fromtimestamp(exp) + timedelta(days=1)).timestamp(),
     }
 
 

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,6 +1,6 @@
 import pytest
-from superjwt.definitions import DefaultHeadersValidationModel, JOSEHeader
-from superjwt.exceptions import InvalidHeaderError, JWTError
+from superjwt.definitions import JOSEHeader
+from superjwt.exceptions import HeaderValidationError, InvalidHeaderError, JWTError
 from superjwt.jws import JWS
 from superjwt.keys import OctKey
 
@@ -22,21 +22,16 @@ def test_not_reset_jws_instance(
     key = OctKey.import_key(secret_key)
     jws_HS256.encode(
         headers=JOSEHeader(alg="HS256"),
-        payload=claims_fixed_dt,
+        payload=claims_fixed_dt.to_dict(),
         key=key,
-        validation_headers=DefaultHeadersValidationModel,
     )
 
     # not reset JWS instance
     with pytest.raises(JWTError):
-        jws_HS256.decode(
-            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
-        )
+        jws_HS256.decode(token=compact, key=key)
 
     jws_HS256.reset()
-    decoded_claims_after_reset = jws_HS256.decode(
-        token=compact, key=key, validation_headers=DefaultHeadersValidationModel
-    )
+    decoded_claims_after_reset = jws_HS256.decode(token=compact, key=key)
     assert decoded_claims_after_reset.decoded.payload == claims_fixed_dt.to_dict()
 
 
@@ -52,9 +47,7 @@ def test_jws_hmac_decoding(jws_HS256: JWS, claims_fixed_dt, secret_key: str):
 
     key = OctKey.import_key(secret_key)
     decoded_claims = JWTCustomClaims(
-        **jws_HS256.decode(
-            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
-        ).decoded.payload
+        **jws_HS256.decode(token=compact, key=key).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()
 
@@ -73,8 +66,20 @@ def test_wrong_header_algorithm(
     key = OctKey.import_key(secret_key)
     headers = JOSEHeader(alg="HS256")
     headers.alg = "ABCDEF"  # wrong algorithm in header  # type: ignore
+
+    with pytest.raises(InvalidHeaderError):
+        jws_HS256.encode(
+            headers=headers,
+            payload=claims_fixed_dt.to_dict(),
+            key=key,
+        )
+    jws_HS256.reset()
+
     invalid_compact = jws_HS256.encode(
-        headers=headers, payload=claims_fixed_dt, key=key, validation_headers=None
+        headers=headers,
+        payload=claims_fixed_dt.to_dict(),
+        key=key,
+        validation_headers=None,
     ).decode("utf-8")
 
     # not reset JWS instance
@@ -82,24 +87,23 @@ def test_wrong_header_algorithm(
         jws_HS256.decode(
             token=invalid_compact,
             key=key,
-            validation_headers=DefaultHeadersValidationModel,
         )
-
     jws_HS256.reset()
-    with pytest.raises(InvalidHeaderError):
+
+    # header validation error, alg is not a valid algorithm
+    with pytest.raises(HeaderValidationError):
         jws_HS256.decode(
             token=invalid_compact,
             key=key,
-            validation_headers=DefaultHeadersValidationModel,
         )
     jws_HS256.reset()
-    jws_token = jws_HS256.decode(token=invalid_compact, key=key, validation_headers=None)
-    assert jws_token.decoded.headers["alg"] == headers.alg
 
+    # algorithm mismatch error
+    with pytest.raises(InvalidHeaderError):
+        jws_HS256.decode(token=invalid_compact, key=key, validation_headers=None)
     jws_HS256.reset()
+
     decoded_claims = JWTCustomClaims(
-        **jws_HS256.decode(
-            token=compact, key=key, validation_headers=DefaultHeadersValidationModel
-        ).decoded.payload
+        **jws_HS256.decode(token=compact, key=key).decoded.payload
     )
     assert decoded_claims.to_dict() == claims_fixed_dt.to_dict()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -47,9 +47,9 @@ def test_encode_decode_dict_claims(claims_dict, secret_key):
 
     # standard claims (datetime data with various input types)
     # they will be serialized uniformly as int (timestamp) thanks to JWTClaims validation
-    assert decoded_claims_dict["iat"] == int(claims_dict["iat"].timestamp())
-    assert decoded_claims_dict["nbf"] == int(claims_dict["nbf"])
-    assert decoded_claims_dict["exp"] == int(claims_dict["exp"].timestamp())
+    assert decoded_claims_dict["iat"] == claims_dict["iat"]
+    assert decoded_claims_dict["nbf"] == claims_dict["nbf"]
+    assert decoded_claims_dict["exp"] == claims_dict["exp"]
 
     # custom claims
     # won't be any type conversion here, nor validation
@@ -224,16 +224,37 @@ def test_encode_decode_claims_dict_validation_disabled(
     check_claims_instance(claims, decoded_claims)
 
 
-def test_required_field_missing(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+def test_custom_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     claims.sub = None  # remove required field 'sub'  # type: ignore
+    jwt.encode(
+        claims=claims, key=secret_key
+    )  # passes because compliant with default JWTClaims
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims=claims, key=secret_key)
-    encoded = jwt.encode(claims, secret_key, validation_claims=None)
+        jwt.encode(claims=claims, key=secret_key, validation_claims=JWTCustomClaims)
+
+    claims.aud = 123  # invalid registered claim  # type: ignore
+    with pytest.raises(ClaimsValidationError):
+        jwt.encode(
+            claims=claims, key=secret_key
+        )  # no more compliant with default JWTClaims
+    with pytest.raises(ClaimsValidationError):
+        jwt.encode(claims=claims, key=secret_key, validation_claims=JWTCustomClaims)
+
+    encoded = jwt.encode(
+        claims, secret_key, validation_claims=None
+    )  # create token anyway
+    with pytest.raises(ClaimsValidationError):
+        jwt.decode(token=encoded, key=secret_key)  # fails default JWTClaims validation
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key, validation_claims=JWTCustomClaims)
     decoded = jwt.decode(token=encoded, key=secret_key, validation_claims=None)
     with pytest.raises(pydantic.ValidationError):
         JWTCustomClaims(**decoded)
+
+    encoded = jwt.encode(claims, secret_key, validation_claims=None)
+    jwt.detach_payload()  # switch to detached mode
+    with pytest.raises(ClaimsValidationError):
+        jwt.decode(token=encoded, key=secret_key, with_detached_payload=claims.to_dict())
 
 
 def test_unsupported_b64_header(jwt: JWT, claims: JWTCustomClaims, secret_key: str):


### PR DESCRIPTION
Better behavior:
- :boom: breaking change: strictly separate validation and model data. Claims dict with datetime will now crash, which should have been the intended behavior from the start. Non JSON serialized data in claims dict will not work. Use pydantic models instead.
- perform validation during encoding or decoding once and only once
- default validation is always `JOSEHeader` / `JWTClaims` unless overidden in `validation_***` params
- better tests for custom validation
- `strict_crit_check` boolean is now in the `JOSEHeader` model as a private attr instead of a JWS variable