### PR TITLE
refactor: partial validation behavior revert and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### :sparkles: New
 
-- validate claims or headers with custom pydantic models for `decode()` ([#21])
-- expired token now raises `TokenExpiredError` upon validation ([#24])
+- validate claims or headers with custom pydantic models for `decode()` ([#34])
+- expired token now raises `TokenExpiredError` upon claims validation ([#24])
 
 ### :gear: Changes
 
@@ -13,8 +13,17 @@
     - defaulting with no `'iat'` set
     - `with_issued_at()` method added
     - modular model with reusable mixins
-- Refactoring of claims and headers validation ([#21]) ([#30])
-    - `encode()` and `decode()` have now the same validation behavior with `validation_claims` (default to `JWTClaims`) and `validation_headers` (default to `JOSEHeader`) parameters. Disable it by setting to `None`
+- Refactoring of claims and headers validation ([#34])
+    - `encode()` new validation default behavior:
+        - when `claims` is passed as a pydantic instance, do validation with the pydantic model automatically
+        - when `claims` is passed as a dict or empty, no automatic validation
+        - when `headers` (optional) is passed as a pydantic instance, do validation with the pydantic model automatically
+        - when `headers` (optional) is passed as a dict, validate against `JOSEHeader`
+    - `decode()` new validation default behavior:
+        - no automatic validation for claims by default, `validation_claims` must be specified to a pydantic model
+        - headers are automatically validated against `JOSEHeader`
+    - claims & headers validation can be overridden by passing a pydantic model to `validation_claims` & `validation_headers` params in `encode()` / `decode()`
+    - claims & headers validation can be disabled by passing `None` to `validation_claims` & `validation_headers` params in `encode()` / `decode()`
     - claims data sent as dict are no longer serialized with Pydantic (datetime object will no longer work). Usage of Pydantic models is recommended instead.
 
 ## v0.2.0 (2025-12-27)
@@ -49,9 +58,8 @@
 
 :tada: superjwt repository initialization
 
-[#30]: /../../issues/30
+[#34]: /../../issues/34
 [#24]: /../../issues/24
-[#21]: /../../issues/21
 [#17]: /../../issues/17
 [#15]: /../../issues/15
 [#14]: /../../issues/14

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypeVar
 
 from pydantic import (
     AfterValidator,
@@ -352,15 +352,65 @@ def make_key(algorithm: Algorithm | Literal["none"], key: str | bytes) -> BaseKe
     return key_type.import_key(key)
 
 
+class JWTHeadersValidationDefault(JOSEHeader):
+    """
+    Placeholder pydantic model for default headers validation state.
+    """
+
+
+class JWTClaimsValidationDefault(JWTClaims):
+    """
+    Placeholder pydantic model for default claims validation state.
+    """
+
+
+ValidationModelType = TypeVar("ValidationModelType", bound=type[JWTBaseModel])
+
+
 def get_effective_data_model(
     data: JWTBaseModel | dict[str, Any],
-    validation_model: type[JWTBaseModel] | None,
-) -> type[JWTBaseModel]:
-    if isinstance(data, JWTBaseModel):
-        return type(data)
-    if validation_model is not None:
+    validation_model: ValidationModelType | None,
+    default: ValidationModelType,
+) -> ValidationModelType:
+    # Used for encoding and decoding
+
+    # case data is already a pydantic instance (only for encoding)
+    # --> return current model
+    if isinstance(data, BaseModel):
+        return type(data)  # type: ignore[return-value]
+
+    # case data is a dict (for encoding and decoding)
+    # and validation model was explicitly specified
+    # --> return model from validation_model if specified
+    if validation_model is not None and validation_model not in (
+        JWTClaimsValidationDefault,
+        JWTHeadersValidationDefault,
+    ):
         return validation_model
-    return JWTBaseModel
+    # --> return default model otherwise
+    return default
+
+
+def get_effective_data_validation_model(
+    data: JWTBaseModel | dict[str, Any],
+    validation_model: ValidationModelType | None,
+    default: ValidationModelType,
+) -> ValidationModelType | None:
+    # For encoding only
+
+    # case validation was explicitly set (disabled or custom pydantic models)
+    if validation_model is None or validation_model not in (
+        JWTClaimsValidationDefault,
+        JWTHeadersValidationDefault,
+    ):
+        return validation_model
+
+    # case validation model is unspecified
+    # --> override default validation model if data is already a pydantic model
+    if isinstance(data, BaseModel):
+        return type(data)  # type: ignore[return-value]
+    # --> use specified default validation model instead (claims or headers is a dict)
+    return default
 
 
 def prepare_and_validate_data(

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -10,8 +10,9 @@ from superjwt.definitions import (
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
-    JWTBaseModel,
+    JWTHeadersValidationDefault,
     get_effective_data_model,
+    get_effective_data_validation_model,
     get_jws_algorithm,
     prepare_and_validate_data,
 )
@@ -58,7 +59,7 @@ class JWS:
         payload: dict[str, Any],
         key: BaseKey,
         *,
-        validation_headers: type[JOSEHeader] | None = JOSEHeader,
+        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
     ) -> bytes:
         if self.token.validated.encoded.compact != b"..":
             raise JWTError("JWS instance data must be reset")
@@ -66,7 +67,9 @@ class JWS:
         # prepare headers data and perform validation
         if headers is None:
             headers = JOSEHeader.make_default(cast("Algorithm", self.algorithm.name))
-
+        validation_headers = get_effective_data_validation_model(
+            headers, validation_headers, default=JOSEHeader
+        )
         try:
             headers_dict = prepare_and_validate_data(
                 data=headers,
@@ -77,7 +80,9 @@ class JWS:
             raise HeaderValidationError(validation_errors=e.errors()) from e
 
         # set headers data
-        default_headers_model = get_effective_data_model(headers, validation_headers)
+        default_headers_model = get_effective_data_model(
+            headers, validation_headers, default=JOSEHeader
+        )
         self.token.validated.model.headers = cast(
             "JOSEHeader", default_headers_model.model_construct(**headers_dict)
         )
@@ -105,7 +110,7 @@ class JWS:
         key: BaseKey,
         *,
         with_detached_payload: dict[str, Any] | None = None,
-        validation_headers: type[JOSEHeader] | None = JOSEHeader,
+        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
     ) -> JWSToken:
         if (
             self.token.validated.encoded.compact != b".."
@@ -219,7 +224,7 @@ class JWS:
 
     def validate_headers_and_algorithm(
         self,
-        validation_model: type[JWTBaseModel] | None,
+        validation_model: type[JOSEHeader] | None,
     ) -> None:
         headers_dict = self.token.unsafe.decoded.headers
 
@@ -234,9 +239,11 @@ class JWS:
 
         # set headers model data
         headers_dict = self.token.unsafe.decoded.headers
-        default_headers_model = get_effective_data_model(headers_dict, validation_model)
+        headers_model = get_effective_data_model(
+            headers_dict, validation_model, default=JOSEHeader
+        )
         self.token.unsafe.model.headers = headers_validated = cast(
-            "JOSEHeader", default_headers_model.model_construct(**headers_dict)
+            "JOSEHeader", headers_model.model_construct(**headers_dict)
         )
 
         # check algorithm match

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -9,7 +9,10 @@ from superjwt.definitions import (
     JWSToken,
     JWTBaseModel,
     JWTClaims,
+    JWTClaimsValidationDefault,
+    JWTHeadersValidationDefault,
     get_effective_data_model,
+    get_effective_data_validation_model,
     make_key,
     prepare_and_validate_data,
 )
@@ -39,8 +42,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = JWTClaims,
-        validation_headers: type[JOSEHeader] | None = JOSEHeader,
+        validation_claims: type[JWTBaseModel] | None = JWTClaimsValidationDefault,
+        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
     ) -> bytes:
         """Encode and sign the claims as a JWT token
 
@@ -53,10 +56,12 @@ class JWT:
                 in the JWT. Will use default JWS headers if not provided.
             validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
-                Defaults to JWTClaims. (standard RFC 7519 registered claims)
+                If 'claims' is a pydantic instance, defaults to its pydantic model.
+                Otherwise, defaults to JWTBaseModel (i.e. no validation).
             validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
-                Defaults to JOSEHeader. (standard JOSE Header)
+                If 'headers' is a pydantic instance, defaults to its pydantic model.
+                Otherwise, defaults to JOSEHeader (standard JOSE Header).
 
         Returns:
             bytes: the encoded compact JWT token
@@ -68,6 +73,9 @@ class JWT:
         # prepare claims data and perform validation
         if claims is None:
             claims = JWTBaseModel()
+        validation_claims = get_effective_data_validation_model(
+            claims, validation_claims, default=JWTBaseModel
+        )
         try:
             claims_dict = prepare_and_validate_data(
                 data=claims,
@@ -91,8 +99,10 @@ class JWT:
         )
 
         # set claims model data
-        default_claims_model = get_effective_data_model(claims, validation_claims)
-        self.jws.token.validated.model.claims = default_claims_model.model_construct(
+        claims_model = get_effective_data_model(
+            claims, validation_claims, default=JWTBaseModel
+        )
+        self.jws.token.validated.model.claims = claims_model.model_construct(
             **claims_dict
         )
 
@@ -119,8 +129,8 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         with_detached_payload: JWTClaims | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = JWTClaims,
-        validation_headers: type[JOSEHeader] | None = JOSEHeader,
+        validation_claims: type[JWTBaseModel] | None = None,
+        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
     ) -> dict[str, Any]:
         """Decode the JWT token with signature verification.
 
@@ -132,10 +142,9 @@ class JWT:
                 Detached payload to use for signature verification, if any.
             validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
-                Defaults to JWTClaims. (standard RFC 7519 registered claims)
             validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
-                Defaults to JOSEHeader. (standard JOSE Header)
+                Defaults to JOSEHeader (standard JOSE Header).
 
         Returns:
             dict[str, Any]: The decoded and verified JWT claims as a dictionary.
@@ -163,10 +172,10 @@ class JWT:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
 
             # set claims model data
-            default_claims_model = get_effective_data_model(
-                claims_dict, validation_claims
+            claims_model = get_effective_data_model(
+                claims_dict, validation_claims, default=JWTBaseModel
             )
-            self.jws.token.unsafe.model.claims = default_claims_model.model_construct(
+            self.jws.token.unsafe.model.claims = claims_model.model_construct(
                 **claims_dict
             )
 
@@ -186,21 +195,23 @@ class JWT:
                 key,
                 validation_headers=validation_headers,
             )
+            claims_dict = self.jws.token.validated.decoded.payload
+
             # validate claims
             try:
                 prepare_and_validate_data(
-                    data=self.jws.token.validated.decoded.payload,
+                    data=claims_dict,
                     validation_model=validation_claims,
                 )
             except ValidationError as e:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
 
             # set claims model data
-            default_claims_model = get_effective_data_model(
-                self.jws.token.validated.decoded.payload, validation_claims
+            claims_model = get_effective_data_model(
+                claims_dict, validation_claims, default=JWTBaseModel
             )
-            self.jws.token.validated.model.claims = default_claims_model.model_construct(
-                **self.jws.token.validated.decoded.payload
+            self.jws.token.validated.model.claims = claims_model.model_construct(
+                **claims_dict
             )
 
         self.token = self.jws.token.validated

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,6 +1,6 @@
 import pytest
 from superjwt.definitions import JOSEHeader
-from superjwt.exceptions import HeaderValidationError, InvalidHeaderError, JWTError
+from superjwt.exceptions import InvalidHeaderError, JWTError
 from superjwt.jws import JWS
 from superjwt.keys import OctKey
 
@@ -91,16 +91,13 @@ def test_wrong_header_algorithm(
     jws_HS256.reset()
 
     # header validation error, alg is not a valid algorithm
-    with pytest.raises(HeaderValidationError):
-        jws_HS256.decode(
-            token=invalid_compact,
-            key=key,
-        )
+    with pytest.raises(InvalidHeaderError):
+        jws_HS256.decode(token=invalid_compact, key=key)
     jws_HS256.reset()
 
     # algorithm mismatch error
     with pytest.raises(InvalidHeaderError):
-        jws_HS256.decode(token=invalid_compact, key=key, validation_headers=None)
+        jws_HS256.decode(token=invalid_compact, key=key)
     jws_HS256.reset()
 
     decoded_claims = JWTCustomClaims(

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -4,9 +4,16 @@ from typing import TYPE_CHECKING, Annotated, Any
 import pydantic
 import pytest
 from superjwt import decode, encode
-from superjwt.definitions import JWTClaims, JWTDatetime, check_future_dates
+from superjwt.definitions import (
+    JOSEHeader,
+    JWTBaseModel,
+    JWTClaims,
+    JWTDatetime,
+    check_future_dates,
+)
 from superjwt.exceptions import (
     ClaimsValidationError,
+    HeaderValidationError,
     InvalidHeaderError,
     JWTError,
     SignatureVerificationFailedError,
@@ -186,8 +193,12 @@ def test_encode_decode_claims_validation_disabled(
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=unvalidated_claims, key=secret_key_random)
     encoded = jwt.encode(unvalidated_claims, secret_key_random, validation_claims=None)
+
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key_random)
+        jwt.decode(
+            token=encoded, key=secret_key_random, validation_claims=JWTCustomClaims
+        )
+    jwt.decode(token=encoded, key=secret_key_random)  # passes (no validation)
     decoded = jwt.decode(token=encoded, key=secret_key_random, validation_claims=None)
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
@@ -204,14 +215,24 @@ def test_encode_decode_claims_dict_validation_disabled(
     # prepare an invalid claims dict
     unvalidated_claims_dict = claims_dict.copy()
     unvalidated_claims_dict["sub"] = 1  # invalid type for sub
+    jwt.encode(
+        claims=unvalidated_claims_dict, key=secret_key_random
+    )  # passes (no encode validation as dict)
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims=unvalidated_claims_dict, key=secret_key_random)
+        jwt.encode(
+            claims=unvalidated_claims_dict,
+            key=secret_key_random,
+            validation_claims=JWTClaims,
+        )
     # run encoding again with validation disabled, does not raise error
     encoded = jwt.encode(
         unvalidated_claims_dict, secret_key_random, validation_claims=None
     )
+    jwt.decode(
+        token=encoded, key=secret_key_random
+    )  # passes (no decode validation as dict)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key_random)
+        jwt.decode(token=encoded, key=secret_key_random, validation_claims=JWTClaims)
     # run decoding again with validation disabled, does not raise error
     decoded = jwt.decode(token=encoded, key=secret_key_random, validation_claims=None)
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
@@ -226,35 +247,64 @@ def test_encode_decode_claims_dict_validation_disabled(
 
 def test_custom_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     claims.sub = None  # remove required field 'sub'  # type: ignore
+
     jwt.encode(
-        claims=claims, key=secret_key
-    )  # passes because compliant with default JWTClaims
+        claims=claims, key=secret_key, validation_claims=JWTClaims
+    )  # passes because compliant with JWTClaims
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=claims, key=secret_key, validation_claims=JWTCustomClaims)
+    with pytest.raises(ClaimsValidationError):
+        jwt.encode(
+            claims=claims, key=secret_key
+        )  # same as validation_claims=JWTCustomClaims (pydantic object is validated by default)
 
     claims.aud = 123  # invalid registered claim  # type: ignore
     with pytest.raises(ClaimsValidationError):
         jwt.encode(
-            claims=claims, key=secret_key
-        )  # no more compliant with default JWTClaims
+            claims=claims, key=secret_key, validation_claims=JWTClaims
+        )  # no more compliant with JWTClaims (aud should be str | list[str] | None)
+
     with pytest.raises(ClaimsValidationError):
         jwt.encode(claims=claims, key=secret_key, validation_claims=JWTCustomClaims)
+    with pytest.raises(ClaimsValidationError):
+        jwt.encode(
+            claims=claims, key=secret_key
+        )  # same as validation_claims=JWTCustomClaims
 
     encoded = jwt.encode(
         claims, secret_key, validation_claims=None
     )  # create token anyway
+    jwt.decode(token=encoded, key=secret_key)  # passes (no validation)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key)  # fails default JWTClaims validation
+        jwt.decode(
+            token=encoded, key=secret_key, validation_claims=JWTClaims
+        )  # fails JWTClaims validation (aud wrong type)
     with pytest.raises(ClaimsValidationError):
         jwt.decode(token=encoded, key=secret_key, validation_claims=JWTCustomClaims)
     decoded = jwt.decode(token=encoded, key=secret_key, validation_claims=None)
     with pytest.raises(pydantic.ValidationError):
         JWTCustomClaims(**decoded)
 
-    encoded = jwt.encode(claims, secret_key, validation_claims=None)
-    jwt.detach_payload()  # switch to detached mode
+    # test detached payload
+    jwt.encode(claims, secret_key, validation_claims=None)
+    encoded = jwt.detach_payload()  # switch to detached mode
+    jwt.decode(
+        token=encoded, key=secret_key, with_detached_payload=claims.to_dict()
+    )  # passes (no validation)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(token=encoded, key=secret_key, with_detached_payload=claims.to_dict())
+        jwt.decode(
+            token=encoded,
+            key=secret_key,
+            with_detached_payload=claims.to_dict(),
+            validation_claims=JWTClaims,
+        )
+    with pytest.raises(ClaimsValidationError):
+        jwt.decode(
+            token=encoded,
+            key=secret_key,
+            with_detached_payload=claims.to_dict(),
+            validation_claims=JWTCustomClaims,
+        )
 
 
 def test_unsupported_b64_header(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
@@ -271,24 +321,45 @@ def test_invalid_claims_future_dates(jwt: JWT, secret_key: str):
     now = datetime.now(UTC)
 
     # exp <= iat is invalid
-    claims_dict = {"sub": "user123", "iat": now, "exp": now - timedelta(minutes=5)}
+    claims_dict = {
+        "sub": "user123",
+        "iat": now.timestamp(),
+        "exp": (now - timedelta(minutes=5)).timestamp(),
+    }
+
+    jwt.encode(claims=claims_dict, key=secret_key)  # no validation
+    jwt.encode(
+        claims=claims_dict, key=secret_key, validation_claims=None
+    )  # no validation
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims=claims_dict, key=secret_key)
+        jwt.encode(claims=claims_dict, key=secret_key, validation_claims=JWTClaims)
 
     # nbf <= iat is invalid
-    claims_dict = {"sub": "user123", "iat": now, "nbf": now - timedelta(minutes=5)}
+    claims_dict = {
+        "sub": "user123",
+        "iat": now.timestamp(),
+        "nbf": (now - timedelta(minutes=5)).timestamp(),
+    }
+    jwt.encode(claims=claims_dict, key=secret_key)  # no validation
+    jwt.encode(
+        claims=claims_dict, key=secret_key, validation_claims=None
+    )  # no validation
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims=claims_dict, key=secret_key)
+        jwt.encode(claims=claims_dict, key=secret_key, validation_claims=JWTClaims)
 
     # nbf >= exp is invalid
     claims_dict = {
         "sub": "user123",
-        "iat": now,
-        "nbf": now + timedelta(days=5),
-        "exp": now + timedelta(minutes=5),
+        "iat": now.timestamp(),
+        "nbf": (now + timedelta(days=5)).timestamp(),
+        "exp": (now + timedelta(minutes=5)).timestamp(),
     }
+    jwt.encode(claims=claims_dict, key=secret_key)  # no validation
+    jwt.encode(
+        claims=claims_dict, key=secret_key, validation_claims=None
+    )  # no validation
     with pytest.raises(ClaimsValidationError):
-        encode(claims=claims_dict, key=secret_key)
+        jwt.encode(claims=claims_dict, key=secret_key, validation_claims=JWTClaims)
 
 
 def test_claims_type_error(jwt: JWT, secret_key: str):
@@ -386,7 +457,96 @@ def test_expired_token(jwt: JWT, secret_key: str):
     token = jwt.encode(claims=claims, key=secret_key, validation_claims=None)
     with pytest.raises(TokenExpiredError):
         jwt.encode(claims=claims, key=secret_key)
+    jwt.decode(token=token, key=secret_key)  # passes (no validation)
     decoded = jwt.decode(token=token, key=secret_key, validation_claims=None)
     assert decoded["exp"] == claims.to_dict()["exp"]
-    with pytest.raises(TokenExpiredError):
-        jwt.decode(token=token, key=secret_key)
+
+
+def test_claims_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+    jwt.encode(claims, key=secret_key, validation_claims=JWTCustomClaims)
+    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
+    jwt.encode(claims, key=secret_key)
+    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
+    jwt.encode(claims, key=secret_key, validation_claims=None)
+    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
+    jwt.encode(claims.to_dict(), key=secret_key, validation_claims=JWTCustomClaims)
+    jwt.encode(claims.to_dict(), key=secret_key)
+    assert isinstance(jwt.token.model.claims, JWTBaseModel)
+    token = jwt.encode(claims.to_dict(), key=secret_key, validation_claims=None)
+    assert isinstance(jwt.token.model.claims, JWTBaseModel)
+
+    jwt.decode(token, key=secret_key, validation_claims=JWTCustomClaims)
+    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
+    jwt.decode(token, key=secret_key)
+    assert isinstance(jwt.token.model.claims, JWTBaseModel)
+    jwt.decode(token, key=secret_key, validation_claims=None)
+    assert isinstance(jwt.token.model.claims, JWTBaseModel)
+
+
+def test_custom_headers_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+    class CustomHeader(JOSEHeader):
+        custom_header: str
+
+    headers = CustomHeader.model_construct(alg="HS256")
+
+    # pydantic headers
+    jwt.encode(
+        claims=claims, key=secret_key, headers=headers, validation_headers=JOSEHeader
+    )  # passes
+    with pytest.raises(HeaderValidationError):
+        jwt.encode(claims=claims, key=secret_key, headers=headers)
+
+    headers.typ = 123  # invalid type for typ # type: ignore
+    with pytest.raises(HeaderValidationError):
+        jwt.encode(
+            claims=claims,
+            key=secret_key,
+            headers=headers,
+            validation_headers=JOSEHeader,  # no longer compliant (typ should be str)
+        )
+    with pytest.raises(HeaderValidationError):
+        jwt.encode(claims=claims, key=secret_key, headers=headers)
+
+    token = jwt.encode(claims, key=secret_key, headers=headers, validation_headers=None)
+    decoded = jwt.decode(token=token, key=secret_key, validation_headers=None)
+    with pytest.raises(HeaderValidationError):
+        jwt.decode(
+            token=token, key=secret_key
+        )  # fails because validation defaults to JOSEHeader
+    with pytest.raises(HeaderValidationError):
+        jwt.decode(token=token, key=secret_key, validation_headers=JOSEHeader)
+    with pytest.raises(HeaderValidationError):
+        jwt.decode(token=token, key=secret_key, validation_headers=CustomHeader)
+    assert decoded == claims.to_dict()
+
+
+def test_headers_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+    class CustomHeader(JOSEHeader):
+        custom_header: str
+
+    headers = CustomHeader(alg="HS256", custom_header="custom_value")
+
+    # check header model
+    jwt.encode(claims, key=secret_key, headers=headers, validation_headers=CustomHeader)
+    assert isinstance(jwt.token.model.headers, CustomHeader)
+    jwt.encode(claims, key=secret_key, headers=headers)
+    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    jwt.encode(claims, key=secret_key, headers=headers, validation_headers=None)
+    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    jwt.encode(
+        claims, key=secret_key, headers=headers.to_dict(), validation_headers=CustomHeader
+    )
+    assert isinstance(jwt.token.model.headers, CustomHeader)
+    jwt.encode(claims, key=secret_key, headers=headers.to_dict())
+    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    token = jwt.encode(
+        claims, key=secret_key, headers=headers.to_dict(), validation_headers=None
+    )
+    assert isinstance(jwt.token.model.headers, JOSEHeader)
+
+    jwt.decode(token, key=secret_key, validation_headers=CustomHeader)
+    assert isinstance(jwt.token.model.headers, CustomHeader)
+    jwt.decode(token, key=secret_key)
+    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    jwt.decode(token, key=secret_key, validation_headers=None)
+    assert isinstance(jwt.token.model.headers, JOSEHeader)


### PR DESCRIPTION
- Refactoring of claims and headers validation
    - `encode()` new validation default behavior:
        - when `claims` is passed as a pydantic instance, do validation with the pydantic model automatically
        - when `claims` is passed as a dict or empty, no automatic validation
        - when `headers` (optional) is passed as a pydantic instance, do validation with the pydantic model automatically
        - when `headers` (optional) is passed as a dict, validate against `JOSEHeader`
    - `decode()` new validation default behavior:
        - no automatic validation for claims by default, `validation_claims` must be specified to a pydantic model
        - headers are automatically validated against `JOSEHeader`
    - claims & headers validation can be overridden by passing a pydantic model to `validation_claims` & `validation_headers` params in `encode()` / `decode()`
    - claims & headers validation can be disabled by passing `None` to `validation_claims` & `validation_headers` params in `encode()` / `decode()`
 - More tests

Follows #21 and #30