### PR TITLE
Default validation policy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### :sparkles: New
+
+- default validation behavior for claims and headers can now be customized with `JWTValidationModelConfig` ([#38])
+
 ## v0.3.0 (2025-12-30)
 
 ### :sparkles: New
@@ -59,6 +65,7 @@
 
 :tada: superjwt repository initialization
 
+[#38]: /../../issues/38
 [#34]: /../../issues/34
 [#31]: /../../issues/31
 [#24]: /../../issues/24

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Annotated, Any, Literal, TypeVar
+from typing import Annotated, Any, Final, Literal
 
 from pydantic import (
     AfterValidator,
@@ -361,73 +361,94 @@ def make_key(algorithm: Algorithm | Literal["none"], key: str | bytes) -> BaseKe
     return key_type.import_key(key)
 
 
-class JWTHeadersValidationDefault(JOSEHeader):
-    """
-    Placeholder pydantic model for default headers validation state.
-    """
+class JWTValidationModelConfig(BaseModel):
+    enabled: bool = True
+
+    # validation
+    default_validation_model: type[BaseModel] = JWTBaseModel
+    force_validation_on_pydantic_model: bool = True
+
+    # data storage
+    default_data_model: type[BaseModel] = JWTBaseModel
 
 
-class JWTClaimsValidationDefault(JWTClaims):
-    """
-    Placeholder pydantic model for default claims validation state.
-    """
+JWTDisabledValidationConfig = JWTValidationModelConfig(enabled=False)
+
+JWTClaimsDefaultValidationConfig = JWTValidationModelConfig(
+    default_validation_model=JWTBaseModel,
+    force_validation_on_pydantic_model=True,
+    default_data_model=JWTBaseModel,
+)
+JWTHeadersDefaultValidationConfig = JWTValidationModelConfig(
+    default_validation_model=JOSEHeader,
+    force_validation_on_pydantic_model=True,
+    default_data_model=JOSEHeader,
+)
 
 
-ValidationModelType = TypeVar("ValidationModelType", bound=type[JWTBaseModel])
+class DefaultValidationFlag: ...
+
+
+DefaultValidation: Final = DefaultValidationFlag()
 
 
 def get_effective_data_model(
     data: JWTBaseModel | dict[str, Any],
-    validation_model: ValidationModelType | None,
-    default: ValidationModelType,
-) -> ValidationModelType:
-    # Used for encoding and decoding
+    validation_model: type[BaseModel] | JWTValidationModelConfig | None,
+) -> type[BaseModel]:
+    """Determine the effective pydantic model to use for internal data storage."""
 
-    # case data is already a pydantic instance (only for encoding)
-    # --> return current model
-    if isinstance(data, BaseModel):
-        return type(data)  # type: ignore[return-value]
+    # 1. case validation is disabled (use generic)
+    if validation_model is None:
+        return JWTBaseModel
 
-    # case data is a dict (for encoding and decoding)
-    # and validation model was explicitly specified
-    # --> return model from validation_model if specified
-    if validation_model is not None and validation_model not in (
-        JWTClaimsValidationDefault,
-        JWTHeadersValidationDefault,
-    ):
-        return validation_model
-    # --> return default model otherwise
-    return default
+    # 2. case when data is not a pydantic model (a dict)
+    if not isinstance(data, BaseModel):
+        # 2.1 validation model was specified (use it)
+        if not isinstance(validation_model, JWTValidationModelConfig):
+            return validation_model
+        # 2.2 no validation model was specified (use default data model)
+        return validation_model.default_data_model
+
+    # 3. case when data is already a pydantic model (use it)
+    return type(data)
 
 
 def get_effective_data_validation_model(
     data: JWTBaseModel | dict[str, Any],
-    validation_model: ValidationModelType | None,
-    default: ValidationModelType,
-) -> ValidationModelType | None:
-    # For encoding only
+    validation_model: type[BaseModel] | JWTValidationModelConfig | None,
+) -> type[BaseModel] | None:
+    """Determine the effective pydantic model to use for internal data validation."""
 
-    # case validation was explicitly set (disabled or custom pydantic models)
-    if validation_model is None or validation_model not in (
-        JWTClaimsValidationDefault,
-        JWTHeadersValidationDefault,
-    ):
+    # 1. case validation is disabled
+    if validation_model is None:
+        return None
+
+    # 2. case validation model was specified (use it)
+    if not isinstance(validation_model, JWTValidationModelConfig):
         return validation_model
 
-    # case validation model is unspecified
-    # --> override default validation model if data is already a pydantic model
-    if isinstance(data, BaseModel):
-        return type(data)  # type: ignore[return-value]
-    # --> use specified default validation model instead (claims or headers is a dict)
-    return default
+    # 3. case validation model was not specified (is a JWTValidationModelConfig)
+    # 3.1 case data is not a pydantic model (a dict)
+    if not isinstance(data, BaseModel):
+        return validation_model.default_validation_model
+    # 3.2 case data is already a pydantic model
+    else:
+        # 3.2.1 override default behavior to use data pydantic model itself
+        if validation_model.force_validation_on_pydantic_model:
+            return type(data)
+        # 3.2.2 use default behavior
+        else:
+            return validation_model.default_validation_model
 
 
 def prepare_and_validate_data(
     data: JWTBaseModel | dict[str, Any],
-    validation_model: type[JWTBaseModel] | None,
-    *,
-    type_err_msg: str = "Wrong data type for pydantic model preparation",
+    validation_model: type[BaseModel] | None,
+    type_err_msg: str | None = None,
 ) -> dict[str, Any]:
+    """Prepare data as dict and perform pydantic validation if required."""
+
     # 1. Prepare data as dict for pydantic validation
     # --> case data is a dict
     if isinstance(data, dict):
@@ -436,7 +457,11 @@ def prepare_and_validate_data(
     elif isinstance(data, BaseModel):
         data_dict = data.model_dump(exclude_none=True)
     else:
-        raise TypeError(type_err_msg)
+        raise TypeError(
+            "Wrong type during data preparation and validation"
+            if type_err_msg is None
+            else f": {type_err_msg}"
+        )
 
     # 2. Validate data
     if validation_model is not None:

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -1,16 +1,19 @@
 import json
 from typing import Any, Literal, cast
 
-from pydantic import SecretBytes, ValidationError
+from pydantic import BaseModel, SecretBytes, ValidationError
 
 from superjwt.algorithms import BaseJWSAlgorithm, NoneAlgorithm
 from superjwt.definitions import (
     MAX_TOKEN_LENGTH,
     Algorithm,
+    DefaultValidation,
+    DefaultValidationFlag,
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
-    JWTHeadersValidationDefault,
+    JWTHeadersDefaultValidationConfig,
+    JWTValidationModelConfig,
     get_effective_data_model,
     get_effective_data_validation_model,
     get_jws_algorithm,
@@ -34,6 +37,8 @@ class JWS:
         self,
         algorithm: Algorithm | Literal["none"],
         max_token_size: int = MAX_TOKEN_LENGTH,
+        default_headers_validation: JWTValidationModelConfig
+        | None = JWTHeadersDefaultValidationConfig,
     ):
         self.token: JWSTokenLifeCycle = JWSTokenLifeCycle()
         self.algorithm: BaseJWSAlgorithm[BaseKey] = get_jws_algorithm(algorithm)
@@ -42,6 +47,7 @@ class JWS:
 
         self.raw_jws: bytes = b""
         self.max_size = max_token_size
+        self.default_headers_validation = default_headers_validation
         self._allow_none_algorithm = False
 
     def reset(self) -> None:
@@ -60,7 +66,9 @@ class JWS:
         payload: dict[str, Any],
         key: BaseKey,
         *,
-        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
     ) -> bytes:
         if self.token.validated.encoded.compact != b"..":
             raise JWTError("JWS instance data must be reset")
@@ -68,24 +76,23 @@ class JWS:
         # prepare headers data and perform validation
         if headers is None:
             headers = JOSEHeader.make_default(cast("Algorithm", self.algorithm.name))
-        validation_headers = get_effective_data_validation_model(
-            headers, validation_headers, default=JOSEHeader
-        )
         try:
             headers_dict = prepare_and_validate_data(
                 data=headers,
-                validation_model=validation_headers,
                 type_err_msg="headers must be a JOSEHeader instance or a dict",
+                validation_model=self.get_validation_headers_model(
+                    headers, validation_headers
+                ),
             )
         except ValidationError as e:
             raise HeaderValidationError(validation_errors=e.errors()) from e
 
         # set headers data
-        default_headers_model = get_effective_data_model(
-            headers, validation_headers, default=JOSEHeader
-        )
         self.token.validated.model.headers = cast(
-            "JOSEHeader", default_headers_model.model_construct(**headers_dict)
+            "JOSEHeader",
+            self.get_data_headers_model(headers, validation_headers).model_construct(
+                **headers_dict
+            ),
         )
         self.token.validated.decoded.headers = headers_dict
         self.token.validated.encoded.headers = urlsafe_b64encode(
@@ -111,7 +118,9 @@ class JWS:
         key: BaseKey,
         *,
         with_detached_payload: dict[str, Any] | None = None,
-        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
     ) -> JWSToken:
         if (
             self.token.validated.encoded.compact != b".."
@@ -225,7 +234,9 @@ class JWS:
 
     def validate_headers_and_algorithm(
         self,
-        validation_model: type[JOSEHeader] | None,
+        validation_model: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
     ) -> None:
         headers_dict = self.token.unsafe.decoded.headers
 
@@ -233,18 +244,20 @@ class JWS:
         try:
             prepare_and_validate_data(
                 data=headers_dict,
-                validation_model=validation_model,
+                validation_model=self.get_validation_headers_model(
+                    headers_dict, validation_model
+                ),
             )
         except ValidationError as e:
             raise HeaderValidationError(validation_errors=e.errors()) from e
 
         # set headers model data
         headers_dict = self.token.unsafe.decoded.headers
-        headers_model = get_effective_data_model(
-            headers_dict, validation_model, default=JOSEHeader
-        )
         self.token.unsafe.model.headers = headers_validated = cast(
-            "JOSEHeader", headers_model.model_construct(**headers_dict)
+            "JOSEHeader",
+            self.get_data_headers_model(headers_dict, validation_model).model_construct(
+                **headers_dict
+            ),
         )
 
         # check algorithm match
@@ -271,3 +284,37 @@ class JWS:
             self.token.unsafe = JWSToken()
 
         return True
+
+    def get_data_headers_model(
+        self,
+        data: JOSEHeader | dict[str, Any],
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+    ) -> type[BaseModel]:
+        """Get the effective data headers pydantic model"""
+
+        if validation_headers is DefaultValidation:
+            return get_effective_data_model(data, self.default_headers_validation)
+        return get_effective_data_model(
+            data,
+            cast("type[BaseModel] | None", validation_headers),
+        )
+
+    def get_validation_headers_model(
+        self,
+        data: JOSEHeader | dict[str, Any],
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+    ) -> type[BaseModel] | None:
+        """Get the effective validation headers pydantic model"""
+
+        if validation_headers is DefaultValidation:
+            return get_effective_data_validation_model(
+                data, self.default_headers_validation
+            )
+        return get_effective_data_validation_model(
+            data,
+            cast("type[BaseModel] | None", validation_headers),
+        )

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -1,16 +1,19 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from superjwt.definitions import (
     Algorithm,
+    DefaultValidation,
+    DefaultValidationFlag,
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
     JWTClaims,
-    JWTClaimsValidationDefault,
-    JWTHeadersValidationDefault,
+    JWTClaimsDefaultValidationConfig,
+    JWTHeadersDefaultValidationConfig,
+    JWTValidationModelConfig,
     get_effective_data_model,
     get_effective_data_validation_model,
     make_key,
@@ -28,9 +31,18 @@ logger = logging.getLogger(__name__)
 
 
 class JWT:
-    def __init__(self):
+    def __init__(
+        self,
+        default_claims_validation: JWTValidationModelConfig
+        | None = JWTClaimsDefaultValidationConfig,
+        default_headers_validation: JWTValidationModelConfig
+        | None = JWTHeadersDefaultValidationConfig,
+    ) -> None:
         self.jws: JWS
         self.token: JWSToken
+
+        self.default_claims_validation = default_claims_validation
+        self.default_headers_validation = default_headers_validation
 
     def reset_token(self) -> None:
         self.token = JWSToken()
@@ -42,8 +54,12 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = JWTClaimsValidationDefault,
-        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
+        validation_claims: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
     ) -> bytes:
         """Encode and sign the claims as a JWT token
 
@@ -73,14 +89,13 @@ class JWT:
         # prepare claims data and perform validation
         if claims is None:
             claims = JWTBaseModel()
-        validation_claims = get_effective_data_validation_model(
-            claims, validation_claims, default=JWTBaseModel
-        )
         try:
             claims_dict = prepare_and_validate_data(
                 data=claims,
-                validation_model=validation_claims,
                 type_err_msg="claims must be a JWTBaseModel instance or a dict",
+                validation_model=self.get_validation_claims_model(
+                    claims, validation_claims
+                ),
             )
         except ValidationError as e:
             raise ClaimsValidationError(validation_errors=e.errors()) from e
@@ -90,7 +105,9 @@ class JWT:
             key = make_key(algorithm, key)
 
         # encode as JWS
-        self.jws = JWS(algorithm)
+        self.jws = JWS(
+            algorithm, default_headers_validation=self.default_headers_validation
+        )
         self.jws.encode(
             headers=headers,
             payload=claims_dict,
@@ -99,11 +116,11 @@ class JWT:
         )
 
         # set claims model data
-        claims_model = get_effective_data_model(
-            claims, validation_claims, default=JWTBaseModel
-        )
-        self.jws.token.validated.model.claims = claims_model.model_construct(
-            **claims_dict
+        self.jws.token.validated.model.claims = cast(
+            "JWTBaseModel",
+            self.get_data_claims_model(claims, validation_claims).model_construct(
+                **claims_dict
+            ),
         )
 
         self.token = self.jws.token.validated
@@ -129,8 +146,12 @@ class JWT:
         algorithm: Algorithm = "HS256",
         *,
         with_detached_payload: JWTClaims | dict[str, Any] | None = None,
-        validation_claims: type[JWTBaseModel] | None = None,
-        validation_headers: type[JOSEHeader] | None = JWTHeadersValidationDefault,
+        validation_claims: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+        validation_headers: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
     ) -> dict[str, Any]:
         """Decode the JWT token with signature verification.
 
@@ -142,6 +163,7 @@ class JWT:
                 Detached payload to use for signature verification, if any.
             validation_claims (type[JWTBaseModel] | None, opt.): the pydantic model
                 to use for claims validation. If None, claims validation is disabled.
+                Defaults to JWTBaseModel (i.e. no validation).
             validation_headers (type[JOSEHeader] | None, opt.): the pydantic model
                 to use for headers validation. If None, headers validation is disabled.
                 Defaults to JOSEHeader (standard JOSE Header).
@@ -152,7 +174,9 @@ class JWT:
 
         # reset session
         self.reset_token()
-        self.jws = JWS(algorithm)
+        self.jws = JWS(
+            algorithm, default_headers_validation=self.default_headers_validation
+        )
 
         # prepare key
         if not isinstance(key, BaseKey):
@@ -166,18 +190,13 @@ class JWT:
             try:
                 claims_dict = prepare_and_validate_data(
                     data=with_detached_payload,
-                    validation_model=validation_claims,
+                    type_err_msg="detached payload must be a dict or a JWTBaseModel instance",
+                    validation_model=self.get_validation_claims_model(
+                        with_detached_payload, validation_claims
+                    ),
                 )
             except ValidationError as e:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
-
-            # set claims model data
-            claims_model = get_effective_data_model(
-                claims_dict, validation_claims, default=JWTBaseModel
-            )
-            self.jws.token.unsafe.model.claims = claims_model.model_construct(
-                **claims_dict
-            )
 
             # JWS decode
             self.jws.decode(
@@ -195,24 +214,25 @@ class JWT:
                 key,
                 validation_headers=validation_headers,
             )
-            claims_dict = self.jws.token.validated.decoded.payload
 
             # validate claims
             try:
-                prepare_and_validate_data(
-                    data=claims_dict,
-                    validation_model=validation_claims,
+                claims_dict = prepare_and_validate_data(
+                    data=self.jws.token.validated.decoded.payload,
+                    validation_model=self.get_validation_claims_model(
+                        self.jws.token.validated.decoded.payload, validation_claims
+                    ),
                 )
             except ValidationError as e:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
 
-            # set claims model data
-            claims_model = get_effective_data_model(
-                claims_dict, validation_claims, default=JWTBaseModel
-            )
-            self.jws.token.validated.model.claims = claims_model.model_construct(
+        # set claims model data
+        self.jws.token.validated.model.claims = cast(
+            "JWTBaseModel",
+            self.get_data_claims_model(claims_dict, validation_claims).model_construct(
                 **claims_dict
-            )
+            ),
+        )
 
         self.token = self.jws.token.validated
         return self.token.decoded.payload
@@ -246,3 +266,37 @@ class JWT:
         self.token = self.jws.token.unsafe
 
         return self.jws.token.unsafe
+
+    def get_data_claims_model(
+        self,
+        data: JWTBaseModel | dict[str, Any],
+        validation_claims: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+    ) -> type[BaseModel]:
+        """Get the effective data claims pydantic model"""
+
+        if validation_claims is DefaultValidation:
+            return get_effective_data_model(data, self.default_claims_validation)
+        return get_effective_data_model(
+            data,
+            cast("type[BaseModel] | None", validation_claims),
+        )
+
+    def get_validation_claims_model(
+        self,
+        data: JWTBaseModel | dict[str, Any],
+        validation_claims: type[BaseModel]
+        | DefaultValidationFlag
+        | None = DefaultValidation,
+    ) -> type[BaseModel] | None:
+        """Get the effective validation claims pydantic model"""
+
+        if validation_claims is DefaultValidation:
+            return get_effective_data_validation_model(
+                data, self.default_claims_validation
+            )
+        return get_effective_data_validation_model(
+            data,
+            cast("type[BaseModel] | None", validation_claims),
+        )

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -9,6 +9,7 @@ from superjwt.definitions import (
     JWTBaseModel,
     JWTClaims,
     JWTDatetime,
+    JWTValidationModelConfig,
     check_future_dates,
 )
 from superjwt.exceptions import (
@@ -457,18 +458,23 @@ def test_expired_token(jwt: JWT, secret_key: str):
 
 
 def test_claims_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+    # encode + claims as pydantic
     jwt.encode(claims, secret_key, "HS256", validation_claims=JWTCustomClaims)
     assert isinstance(jwt.token.model.claims, JWTCustomClaims)
     jwt.encode(claims, secret_key, "HS256")
     assert isinstance(jwt.token.model.claims, JWTCustomClaims)
     jwt.encode(claims, secret_key, "HS256", validation_claims=None)
-    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
+    assert isinstance(jwt.token.model.claims, JWTBaseModel)
+
+    # encode + claims as dict
     jwt.encode(claims.to_dict(), secret_key, "HS256", validation_claims=JWTCustomClaims)
+    assert isinstance(jwt.token.model.claims, JWTCustomClaims)
     jwt.encode(claims.to_dict(), secret_key, "HS256")
     assert isinstance(jwt.token.model.claims, JWTBaseModel)
     token = jwt.encode(claims.to_dict(), secret_key, "HS256", validation_claims=None)
     assert isinstance(jwt.token.model.claims, JWTBaseModel)
 
+    # decode
     jwt.decode(token, secret_key, "HS256", validation_claims=JWTCustomClaims)
     assert isinstance(jwt.token.model.claims, JWTCustomClaims)
     jwt.decode(token, secret_key, "HS256")
@@ -477,34 +483,35 @@ def test_claims_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     assert isinstance(jwt.token.model.claims, JWTBaseModel)
 
 
-def test_custom_headers_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+def test_custom_headers_validation(jwt: JWT, secret_key: str):
     class CustomHeader(JOSEHeader):
         custom_header: str
 
-    headers = CustomHeader.model_construct(alg="HS256")
+    headers = CustomHeader.model_construct(
+        alg="HS256"
+    )  # non compliant with CustomHeader, but with JOSEHeader
 
     # pydantic headers
     jwt.encode(
-        claims, secret_key, "HS256", headers=headers, validation_headers=JOSEHeader
+        {}, secret_key, "HS256", headers=headers, validation_headers=JOSEHeader
     )  # passes
     with pytest.raises(HeaderValidationError):
-        jwt.encode(claims, secret_key, "HS256", headers=headers)
+        jwt.encode({}, secret_key, "HS256", headers=headers)
 
+    # make headers no more compliant with JOSEHeader
     headers.typ = 123  # invalid type for typ # type: ignore
     with pytest.raises(HeaderValidationError):
         jwt.encode(
-            claims,
+            {},
             secret_key,
             "HS256",
             headers=headers,
             validation_headers=JOSEHeader,  # no longer compliant (typ should be str)
         )
     with pytest.raises(HeaderValidationError):
-        jwt.encode(claims, secret_key, "HS256", headers=headers)
+        jwt.encode({}, secret_key, "HS256", headers=headers)
 
-    token = jwt.encode(
-        claims, secret_key, "HS256", headers=headers, validation_headers=None
-    )
+    token = jwt.encode({}, secret_key, "HS256", headers=headers, validation_headers=None)
     decoded = jwt.decode(token, secret_key, "HS256", validation_headers=None)
     with pytest.raises(HeaderValidationError):
         jwt.decode(
@@ -514,42 +521,194 @@ def test_custom_headers_validation(jwt: JWT, claims: JWTCustomClaims, secret_key
         jwt.decode(token, secret_key, "HS256", validation_headers=JOSEHeader)
     with pytest.raises(HeaderValidationError):
         jwt.decode(token, secret_key, "HS256", validation_headers=CustomHeader)
-    assert decoded == claims.to_dict()
+    assert decoded == {}
 
 
-def test_headers_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
+def test_headers_model_data(jwt: JWT, secret_key: str):
     class CustomHeader(JOSEHeader):
         custom_header: str
 
     headers = CustomHeader(alg="HS256", custom_header="custom_value")
 
-    # check header model
-    jwt.encode(
-        claims, secret_key, "HS256", headers=headers, validation_headers=CustomHeader
-    )
+    # encode + headers as pydantic
+    jwt.encode({}, secret_key, "HS256", headers=headers, validation_headers=CustomHeader)
     assert isinstance(jwt.token.model.headers, CustomHeader)
-    jwt.encode(claims, secret_key, "HS256", headers=headers)
+    jwt.encode({}, secret_key, "HS256", headers=headers)
     assert isinstance(jwt.token.model.headers, JOSEHeader)
-    jwt.encode(claims, secret_key, "HS256", headers=headers, validation_headers=None)
-    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    jwt.encode({}, secret_key, "HS256", headers=headers, validation_headers=None)
+    assert isinstance(jwt.token.model.headers, JWTBaseModel)
+
+    # encode + headers as dict
     jwt.encode(
-        claims,
+        {},
         secret_key,
         "HS256",
         headers=headers.to_dict(),
         validation_headers=CustomHeader,
     )
     assert isinstance(jwt.token.model.headers, CustomHeader)
-    jwt.encode(claims, secret_key, "HS256", headers=headers.to_dict())
+    jwt.encode({}, secret_key, "HS256", headers=headers.to_dict())
     assert isinstance(jwt.token.model.headers, JOSEHeader)
     token = jwt.encode(
-        claims, secret_key, "HS256", headers=headers.to_dict(), validation_headers=None
+        {}, secret_key, "HS256", headers=headers.to_dict(), validation_headers=None
     )
-    assert isinstance(jwt.token.model.headers, JOSEHeader)
 
+    # decode
+    assert isinstance(jwt.token.model.headers, JWTBaseModel)
     jwt.decode(token, secret_key, "HS256", validation_headers=CustomHeader)
     assert isinstance(jwt.token.model.headers, CustomHeader)
     jwt.decode(token, secret_key, "HS256")
     assert isinstance(jwt.token.model.headers, JOSEHeader)
     jwt.decode(token, secret_key, "HS256", validation_headers=None)
-    assert isinstance(jwt.token.model.headers, JOSEHeader)
+    assert isinstance(jwt.token.model.headers, JWTBaseModel)
+
+
+def test_custom_default_claims_validation_policy(
+    claims_dict: dict[str, Any], secret_key: str
+):
+    """Test JWT instance with custom default claims validation policy."""
+
+    # Create JWT instance with strict claims validation by default (JWTClaims)
+    custom_validation_config = JWTValidationModelConfig(
+        default_validation_model=JWTClaims,
+        force_validation_on_pydantic_model=True,
+        default_data_model=JWTClaims,
+    )
+    jwt_strict = JWT(default_claims_validation=custom_validation_config)
+
+    # Valid claims dict should pass validation
+    valid_claims = claims_dict.copy()
+    token = jwt_strict.encode(valid_claims, secret_key, "HS256")
+    decoded = jwt_strict.decode(token, secret_key, "HS256")
+    assert decoded["sub"] == valid_claims["sub"]
+
+    # Invalid claims dict should fail validation (aud must be str or list[str])
+    invalid_claims = claims_dict.copy()
+    invalid_claims["aud"] = 123  # invalid type
+    with pytest.raises(ClaimsValidationError):
+        jwt_strict.encode(invalid_claims, secret_key, "HS256")
+
+    # Test with invalid future dates (exp <= iat)
+    now = datetime.now(UTC)
+    invalid_dates_claims = {
+        "sub": "user123",
+        "iat": now.timestamp(),
+        "exp": (now - timedelta(minutes=5)).timestamp(),
+    }
+    with pytest.raises(ClaimsValidationError):
+        jwt_strict.encode(invalid_dates_claims, secret_key, "HS256")
+
+    # Can still override validation on encode/decode
+    token_unvalidated = jwt_strict.encode(
+        invalid_claims, secret_key, "HS256", validation_claims=None
+    )
+    # Decode with validation_claims=None should pass (no validation)
+    jwt_strict.decode(token_unvalidated, secret_key, "HS256", validation_claims=None)
+    # Decode without specifying validation_claims should fail (uses custom default)
+    with pytest.raises(ClaimsValidationError):
+        jwt_strict.decode(token_unvalidated, secret_key, "HS256")
+
+    # Same for invalid_dates_claims
+    token_invalid_dates = jwt_strict.encode(
+        invalid_dates_claims, secret_key, "HS256", validation_claims=None
+    )
+    # Decode with validation_claims=None should pass (no validation)
+    jwt_strict.decode(token_invalid_dates, secret_key, "HS256", validation_claims=None)
+    # Decode without specifying validation_claims should fail (uses custom default)
+    with pytest.raises(ClaimsValidationError):
+        jwt_strict.decode(token_invalid_dates, secret_key, "HS256")
+
+    # Compare with default JWT instance behavior (no validation for dict claims)
+    jwt_default = JWT()
+    jwt_default.encode(invalid_claims, secret_key, "HS256")  # passes without validation
+
+
+def test_custom_default_headers_validation_policy(secret_key: str):
+    """Test JWT instance with custom default headers validation policy."""
+
+    class CustomHeader(JOSEHeader):
+        custom_header: str
+
+    # Create JWT instance with custom headers validation by default
+    custom_validation_config = JWTValidationModelConfig(
+        default_validation_model=CustomHeader,
+        force_validation_on_pydantic_model=True,
+        default_data_model=CustomHeader,
+    )
+    jwt_custom = JWT(default_headers_validation=custom_validation_config)
+
+    # Valid custom headers should pass validation
+    valid_headers = {"alg": "HS256", "custom_header": "custom_value"}
+    token = jwt_custom.encode({}, secret_key, "HS256", headers=valid_headers)
+    decoded = jwt_custom.decode(token, secret_key, "HS256")
+    assert decoded == {}
+
+    # Missing custom_header should fail validation
+    invalid_headers = {"alg": "HS256"}  # missing custom_header
+    with pytest.raises(HeaderValidationError):
+        jwt_custom.encode({}, secret_key, "HS256", headers=invalid_headers)
+
+    # Can still override validation on encode/decode
+    token_unvalidated = jwt_custom.encode(
+        {}, secret_key, "HS256", headers=invalid_headers, validation_headers=None
+    )
+    # Decode with validation_headers=None should pass (no validation)
+    jwt_custom.decode(token_unvalidated, secret_key, "HS256", validation_headers=None)
+    # Decode without specifying validation_headers should fail (uses custom default)
+    with pytest.raises(HeaderValidationError):
+        jwt_custom.decode(token_unvalidated, secret_key, "HS256")
+
+    # Compare with default JWT instance behavior (validates with JOSEHeader, not CustomHeader)
+    jwt_default = JWT()
+    jwt_default.encode(
+        {}, secret_key, "HS256", headers=invalid_headers
+    )  # passes with JOSEHeader validation
+
+
+def test_custom_default_claims_validation_policy_no_force_pydantic(
+    claims_dict: dict[str, Any], secret_key: str
+):
+    """Test JWT instance with custom default validation but force_validation_on_pydantic_model=False."""
+
+    # Create JWT instance with custom validation but without forcing Pydantic validation
+    # When force_validation_on_pydantic_model=False, Pydantic claims use default_validation_model
+    custom_validation_config = JWTValidationModelConfig(
+        default_validation_model=JWTClaims,  # Validate against JWTClaims
+        force_validation_on_pydantic_model=False,  # Don't force Pydantic model type
+        default_data_model=JWTBaseModel,
+    )
+    jwt_custom = JWT(default_claims_validation=custom_validation_config)
+
+    # Create invalid Pydantic claims (aud has wrong type)
+    invalid_claims = JWTCustomClaims.model_construct(**claims_dict)
+    invalid_claims.aud = 123  # invalid type  # type: ignore
+
+    # Encode with Pydantic claims should validate against JWTClaims (not JWTCustomClaims)
+    # (because force_validation_on_pydantic_model=False and default_validation_model=JWTClaims)
+    with pytest.raises(ClaimsValidationError):
+        jwt_custom.encode(
+            invalid_claims, secret_key, "HS256"
+        )  # fails JWTClaims validation
+
+    # Create valid claims according to JWTClaims but invalid for JWTCustomClaims
+    # (missing required 'user_id' field from JWTCustomClaims)
+    partial_claims = JWTCustomClaims.model_construct(**claims_dict)
+    partial_claims.user_id = (
+        None  # invalid for JWTCustomClaims but valid for JWTClaims  # type: ignore
+    )
+
+    # Should pass because it only validates against JWTClaims (not JWTCustomClaims)
+    token = jwt_custom.encode(partial_claims, secret_key, "HS256")
+    decoded = jwt_custom.decode(token, secret_key, "HS256")
+    assert "user_id" not in decoded  # user_id is None so excluded
+
+    # But explicitly requesting JWTCustomClaims validation should fail
+    with pytest.raises(ClaimsValidationError):
+        jwt_custom.decode(token, secret_key, "HS256", validation_claims=JWTCustomClaims)
+
+    # Compare with default JWT instance behavior (validates Pydantic models automatically)
+    jwt_default = JWT()
+    with pytest.raises(ClaimsValidationError):
+        jwt_default.encode(
+            partial_claims, secret_key, "HS256"
+        )  # fails with default behavior (validates against JWTCustomClaims)


### PR DESCRIPTION
- default validation behavior for claims and headers can now be customized with `JWTValidationModelConfig`
- tests added and subsequently reformatted for the next public interface update

Example: creating a default compliant claims validation
```python
from superjwt.jwt import JWT
from superjwt.definitions import JWTClaims, JWTValidationModelConfig

custom_validation_config = JWTValidationModelConfig(
        default_validation_model=JWTClaims,
        force_validation_on_pydantic_model=True,
        default_data_model=JWTClaims,
    )
jwt = JWT()
jwt_strict = JWT(default_claims_validation=custom_validation_config)

claims_dict = {"sub": 123}  # not compliant with JWTClaims

jwt.encode(claims_dict, secret_key, "HS256")  # passes
jwt.decode(jwt.token.encoded.compact, secret_key, "HS256") # passes

try:
    jwt_strict.encode(claims_dict, secret_key, "HS256")  # fails validation
except ClaimsValidationError as e:
    pass

jwt_strict.encode(claims_dict, secret_key, "HS256", validation_claims=None)
compact = jwt_strict.token.encoded.compact
try:
    jwt_strict.decode(jwt_strict.token.encoded.compact, secret_key, "HS256")  # fails validation
except ClaimsValidationError as e:
    pass
decoded = jwt_strict.decode(compact, secret_key, "HS256", validation_claims=None)
print(decoded)
#> {'sub': 123}
```