### PR TITLE
feat: nbf auto validation, raises TokenNotYetValidError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Validation.DISABLE
 - Default validation behavior for claims and headers can now be customized with `JWTValidationModelConfig` ([#38])
 - `JWT` can receive a `max_token_bytes` parameter to control the allowed max token size ([#40])
+- `JWTClaims` now raises `TokenNotYetValidError` if `'nbf'` not in the past ([#41])
 
 ## :gear: Changes
 
@@ -77,6 +78,7 @@
 :tada: superjwt repository initialization
 
 
+[#41]: /../../issues/41
 [#40]: /../../issues/40
 [#39]: /../../issues/39
 [#38]: /../../issues/38

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -28,6 +28,7 @@ from superjwt.exceptions import (
     InvalidAlgorithmError,
     InvalidHeadersError,
     TokenExpiredError,
+    TokenNotYetValidError,
 )
 from superjwt.keys import BaseKey, NoneKey, OctKey
 
@@ -227,6 +228,22 @@ class JWTClaimsDatetimeMixIn(JWTBaseModel):
             return dt
         if value <= now:
             raise TokenExpiredError()
+        return value
+
+    @field_validator("nbf", check_fields=False)
+    @classmethod
+    def validate_nbf(cls, value: datetime | float | int | None) -> datetime | None:
+        if value is None:
+            return value
+        now = datetime.now(UTC).replace(microsecond=0)
+
+        if isinstance(value, (float, int)):
+            dt = datetime.fromtimestamp(value, tz=UTC)
+            if dt > now:
+                raise TokenNotYetValidError()
+            return dt
+        if value > now:
+            raise TokenNotYetValidError()
         return value
 
     def with_issued_at(self) -> Self:

--- a/superjwt/exceptions.py
+++ b/superjwt/exceptions.py
@@ -104,6 +104,12 @@ class TokenExpiredError(ClaimsValidationError):
     error = "Token has expired"
 
 
+class TokenNotYetValidError(ClaimsValidationError):
+    """Raised when the token is not yet valid based on its 'nbf' claim."""
+
+    error = "Token is not yet valid"
+
+
 class InvalidAlgorithmError(SuperJWTError):
     """Base class for algorithm-related errors."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,8 +80,7 @@ def iat() -> float:
 
 
 @pytest.fixture
-def nbf(iat: float) -> float:
-    return (datetime.fromtimestamp(iat) + timedelta(days=30)).timestamp()
+def nbf() -> None: ...
 
 
 @pytest.fixture

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -24,6 +24,7 @@ from superjwt.exceptions import (
     SizeExceededError,
     SuperJWTError,
     TokenExpiredError,
+    TokenNotYetValidError,
 )
 from superjwt.jwt import JWT
 from superjwt.utils import urlsafe_b64encode
@@ -493,6 +494,46 @@ def test_expired_token(jwt: JWT, secret_key: str):
         compact, secret_key, "HS256", claims_validation=Validation.DISABLE
     ).payload
     assert decoded_claims["exp"] == claims.to_dict()["exp"]
+    with pytest.raises(TokenExpiredError):
+        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+
+    # test with dict
+    past_exp_dict = {
+        "sub": "test_user",
+        "exp": (datetime.now(UTC) - timedelta(days=365)).timestamp(),
+    }
+    compact_dict = jwt.encode(
+        past_exp_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+    ).compact
+    with pytest.raises(TokenExpiredError):
+        jwt.decode(compact_dict, secret_key, "HS256", claims_validation=JWTClaims)
+
+
+def test_not_yet_valid_token(jwt: JWT, secret_key: str):
+    claims = JWTClaims.model_construct(nbf=datetime.now(UTC) + timedelta(days=1))
+    compact = jwt.encode(
+        claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+    ).compact
+    with pytest.raises(TokenNotYetValidError):
+        jwt.encode(claims, secret_key, "HS256")
+    jwt.decode(compact, secret_key, "HS256")  # passes (no validation)
+    decoded_claims = jwt.decode(
+        compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+    ).payload
+    assert decoded_claims["nbf"] == claims.to_dict()["nbf"]
+    with pytest.raises(TokenNotYetValidError):
+        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+
+    # test with dict
+    future_nbf_dict = {
+        "sub": "test_user",
+        "nbf": (datetime.now(UTC) + timedelta(days=365)).timestamp(),
+    }
+    compact_dict = jwt.encode(
+        future_nbf_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+    ).compact
+    with pytest.raises(TokenNotYetValidError):
+        jwt.decode(compact_dict, secret_key, "HS256", claims_validation=JWTClaims)
 
 
 def test_claims_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):


### PR DESCRIPTION
- `JWTClaims` now raises `TokenNotYetValidError` if `'nbf'` not in the past
- tests

Current exceptions tree:
```
SuperJWTError
├── InvalidTokenError
│   ├── SignatureVerificationFailedError
│   ├── SizeExceededError
│   ├── InvalidHeadersError
│   │   ├── HeadersValidationError
│   │   └── AlgorithmMismatchError
│   └── InvalidPayloadError
│       └── ClaimsValidationError
│           ├── TokenExpiredError
│           └── TokenNotYetValidError
├── InvalidAlgorithmError
│   └── AlgorithmNotSupportedError
└── InvalidKeyError
```