### PR TITLE
Always revalidate Pydantic instance

### DIFF
--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -97,6 +97,10 @@ class HttpsUrl(HttpUrl):
 class JWTBaseModel(BaseModel):
     model_config = {"extra": "allow", "revalidate_instances": "always"}
 
+    def revalidate(self) -> None:
+        """Re-validate the pydantic instance against its own model."""
+        self.model_validate(self)
+
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump(exclude_none=True)
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -175,4 +175,4 @@ def test_check_exp_after_nbf_model_validator(jwt: JWT, secret_key: str):
         exp=now - timedelta(days=1),
     )
     with pytest.raises(TokenNotYetValidError):
-        JWTClaims.model_validate(unvalidated_claims)
+        unvalidated_claims.revalidate()


### PR DESCRIPTION
- add `"revalidate_instances": "always"` in `JWTBaseModel` config: pydantic `.model_validate()` will now revalidate the passed instance.
- refactor `prepare_and_validate_data()` to use pydantic `.model_validate()` instead of constructor
- add `JWTBaseModel.revalidate()`  shortcut method to re-validate any pydantic instance.