### PR TITLE
🕙 Time Spoofing

### DIFF
--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -97,12 +97,18 @@ class HttpsUrl(HttpUrl):
 class JWTBaseModel(BaseModel):
     model_config = {"extra": "allow", "revalidate_instances": "always"}
 
+    internal__now: Annotated[datetime | None, Field(exclude=True, repr=False)] = None
+
     def revalidate(self) -> None:
         """Re-validate the pydantic instance against its own model."""
         self.model_validate(self)
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump(exclude_none=True)
+
+    def spoof_time(self, set_now: datetime | None) -> None:
+        """Spoof the current time for testing purposes. Set to None to disable spoofing."""
+        self.internal__now = set_now
 
 
 class JOSEHeader(JWTBaseModel):
@@ -247,6 +253,20 @@ class JWTClaims(JWTClaimsModel):
     JWT standard claims as per RFC 7519.
     """
 
+    @property
+    def now(self) -> datetime:
+        """Get the current time"""
+        if self.internal__now is None:
+            return datetime.now(UTC).replace(microsecond=0)
+        return self.internal__now.replace(microsecond=0)
+
+    @staticmethod
+    def get_now(info: ValidationInfo) -> datetime:
+        now = info.data["internal__now"]
+        if now is None:
+            return datetime.now(UTC).replace(microsecond=0)
+        return now.replace(microsecond=0)
+
     @model_validator(mode="after")
     def check_exp_after_nbf(self) -> Self:
         if self.exp is not None and self.nbf is not None:
@@ -256,39 +276,36 @@ class JWTClaims(JWTClaimsModel):
 
     @field_validator("exp")
     @classmethod
-    def validate_exp(cls, value: datetime | None) -> datetime | None:
+    def validate_exp(
+        cls, value: datetime | None, info: ValidationInfo
+    ) -> datetime | None:
         if value is None:
             return value
-
-        now = datetime.now(UTC).replace(microsecond=0)
-
-        if value <= now:
+        if value <= cls.get_now(info):
             raise TokenExpiredError()
         return value
 
     @field_validator("nbf")
     @classmethod
-    def validate_nbf(cls, value: datetime | None) -> datetime | None:
+    def validate_nbf(
+        cls, value: datetime | None, info: ValidationInfo
+    ) -> datetime | None:
         if value is None:
             return value
-
-        now = datetime.now(UTC).replace(microsecond=0)
-
-        if value > now:
+        if value > cls.get_now(info):
             raise TokenNotYetValidError()
         return value
 
     def with_issued_at(self) -> Self:
         """Return a new JWTClaims instance with the 'iat' claim set to current time."""
-        now = datetime.now(UTC).replace(microsecond=0)
 
         # case iat AND exp were set
         if self.exp is not None and self.iat is not None:
             # preserve original delta between iat and exp
             delta = self.exp - self.iat
-            return self.model_copy(update={"iat": now, "exp": now + delta})
+            return self.model_copy(update={"iat": self.now, "exp": self.now + delta})
 
-        return self.model_copy(update={"iat": now})
+        return self.model_copy(update={"iat": self.now})
 
     def with_expiration(
         self,
@@ -302,13 +319,12 @@ class JWTClaims(JWTClaimsModel):
             raise ValueError(
                 "Expiration minutes, hours, and days must be non-negative integers"
             )
-        now = datetime.now(UTC).replace(microsecond=0)
-        exp_time = now + timedelta(minutes=minutes, hours=hours, days=days)
+        exp_time = self.now + timedelta(minutes=minutes, hours=hours, days=days)
 
         # case iat was already set
         if self.iat is not None:
             # rewrite iat value
-            return self.model_copy(update={"iat": now, "exp": exp_time})
+            return self.model_copy(update={"iat": self.now, "exp": exp_time})
 
         return self.model_copy(update={"exp": exp_time})
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -9,7 +9,6 @@ from superjwt.exceptions import (
     TokenExpiredError,
     TokenNotYetValidError,
 )
-from superjwt.jwt import JWT
 
 
 try:
@@ -125,6 +124,15 @@ def test_validate_nbf_with_datetime_input():
     ):
         JWTClaims(iat=now, nbf=now)
 
+    # Test with_issued_at() preserving exp delta (lines 305-306 in definitions.py)
+    claims_with_both = JWTClaims(
+        iat=now - timedelta(hours=2), exp=now + timedelta(hours=2)
+    )
+    updated = claims_with_both.with_issued_at()
+    assert updated.iat is not None and updated.iat >= now  # New iat is current time
+    assert updated.exp is not None
+    assert (updated.exp - updated.iat) == timedelta(hours=4)  # Delta preserved
+
 
 def test_validate_nbf_with_timestamp_input():
     """Test validate_nbf field validator with int/float timestamp input."""
@@ -159,7 +167,7 @@ def test_validate_nbf_with_timestamp_input():
         JWTClaims(iat=iat_timestamp, nbf=nbf_equal_iat)  # type: ignore[arg-type]
 
 
-def test_check_exp_after_nbf_model_validator(jwt: JWT, secret_key: str):
+def test_check_exp_after_nbf_model_validator():
     """Test check_exp_after_nbf model validator ensures nbf < exp."""
     # nbf < exp
     nbf_ts = int((datetime.now(UTC) - timedelta(days=90)).timestamp())
@@ -168,11 +176,152 @@ def test_check_exp_after_nbf_model_validator(jwt: JWT, secret_key: str):
     assert claims.nbf is not None and claims.exp is not None
     assert claims.nbf < claims.exp
 
-    # nbf >= exp
+    # nbf >= exp with iat=None
     now = datetime.now(UTC).replace(microsecond=0)
-    unvalidated_claims = JWTClaims.model_construct(
-        nbf=now + timedelta(days=1),
-        exp=now - timedelta(days=1),
-    )
+
+    # Make both in future but inverted: nbf > exp
+    future_nbf = now + timedelta(days=2)
+    future_exp = now + timedelta(days=1)
+
+    # This will fail on nbf field validator (nbf in future)
     with pytest.raises(TokenNotYetValidError):
-        unvalidated_claims.revalidate()
+        JWTClaims(nbf=future_nbf, exp=future_exp, iat=None)
+
+    # Try both in past but inverted
+    past_nbf = now - timedelta(days=1)
+    past_exp = now - timedelta(days=2)
+
+    # This will fail on exp field validator (exp in past)
+    with pytest.raises(TokenExpiredError):
+        JWTClaims(nbf=past_nbf, exp=past_exp, iat=None)
+
+
+def test_spoof_time_with_method():
+    """Test time spoofing using the spoof_time() method."""
+    fixed_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+    claims = JWTClaims()
+    claims.spoof_time(fixed_time)
+    assert claims.now == fixed_time
+    assert claims.internal__now == fixed_time
+
+    # Test that exp validation uses spoofed time
+    claims_with_exp = JWTClaims.model_construct(exp=fixed_time + timedelta(hours=1))
+    claims_with_exp.spoof_time(fixed_time)
+    claims_with_exp.revalidate()
+    assert claims_with_exp.exp == fixed_time + timedelta(hours=1)
+
+    # Setting exp equal to fixed_time should raise TokenExpiredError
+    expired_claims = JWTClaims.model_construct(exp=fixed_time)
+    expired_claims.spoof_time(fixed_time)
+    with pytest.raises(TokenExpiredError):
+        expired_claims.revalidate()
+
+    # Revert to normal time
+    claims.spoof_time(None)
+    assert claims.now != fixed_time  # Should be close to actual current time
+
+
+def test_spoof_time_with_exp_validation():
+    """Test exp validation with spoofed time."""
+    fixed_time = datetime(2025, 3, 10, 15, 0, 0, tzinfo=UTC)
+
+    # Test valid exp in the future (relative to spoofed time)
+    future_exp = fixed_time + timedelta(days=30)
+    claims = JWTClaims.model_construct(exp=future_exp)
+    claims.spoof_time(fixed_time)
+    claims.revalidate()
+    assert claims.exp == future_exp
+
+    # Test expired token (exp in the past relative to spoofed time)
+    past_exp = fixed_time - timedelta(days=1)
+    past_claims = JWTClaims.model_construct(exp=past_exp)
+    past_claims.spoof_time(fixed_time)
+    with pytest.raises(TokenExpiredError):
+        past_claims.revalidate()
+
+
+def test_spoof_time_with_nbf_validation():
+    """Test nbf validation with spoofed time."""
+    fixed_time = datetime(2025, 4, 20, 8, 0, 0, tzinfo=UTC)
+
+    # Test valid nbf in the past (relative to spoofed time)
+    past_nbf = fixed_time - timedelta(hours=2)
+    claims = JWTClaims.model_construct(nbf=past_nbf)
+    claims.spoof_time(fixed_time)
+    claims.revalidate()
+    assert claims.nbf == past_nbf
+
+    # Test nbf equal to spoofed time
+    claims_now = JWTClaims.model_construct(nbf=fixed_time)
+    claims_now.spoof_time(fixed_time)
+    claims_now.revalidate()
+    assert claims_now.nbf == fixed_time
+
+    # Test nbf in the future (relative to spoofed time)
+    future_nbf = fixed_time + timedelta(hours=1)
+    future_claims = JWTClaims.model_construct(nbf=future_nbf)
+    future_claims.spoof_time(fixed_time)
+    with pytest.raises(TokenNotYetValidError):
+        future_claims.revalidate()
+
+
+def test_spoof_time_with_iat_exp_relationship():
+    """Test iat and exp relationship with spoofed time."""
+    fixed_time = datetime(2025, 2, 14, 14, 0, 0, tzinfo=UTC)
+
+    # Create claims with iat in past and exp in future (relative to spoofed time)
+    iat_time = fixed_time - timedelta(days=1)
+    exp_time = fixed_time + timedelta(days=1)
+
+    claims = JWTClaims.model_construct(iat=iat_time, exp=exp_time)
+    claims.spoof_time(fixed_time)
+    claims.revalidate()
+
+    assert claims.iat == iat_time
+    assert claims.exp == exp_time
+
+    # Test with_issued_at() uses spoofed time
+    claims_with_iat = JWTClaims()
+    claims_with_iat.spoof_time(fixed_time)
+    updated_claims = claims_with_iat.with_issued_at()
+    assert updated_claims.iat == fixed_time
+
+
+def test_spoof_time_with_expiration_method():
+    """Test with_expiration() method with spoofed time."""
+    fixed_time = datetime(2025, 5, 1, 12, 0, 0, tzinfo=UTC)
+
+    claims = JWTClaims()
+    claims.spoof_time(fixed_time)
+
+    # Add expiration relative to spoofed time
+    claims_with_exp = claims.with_expiration(hours=2)
+    expected_exp = fixed_time + timedelta(hours=2)
+
+    assert claims_with_exp.exp == expected_exp
+    # Note: with_expiration() only sets iat if it was already set
+    # Since we started with empty claims, iat remains None
+    assert claims_with_exp.iat is None
+
+    # Test with iat already set
+    claims_with_iat = JWTClaims(iat=fixed_time - timedelta(days=1))
+    claims_with_iat.spoof_time(fixed_time)
+    claims_with_both = claims_with_iat.with_expiration(hours=2)
+    assert claims_with_both.exp == expected_exp
+    assert claims_with_both.iat == fixed_time
+
+
+def test_spoof_time_revert_to_normal():
+    """Test reverting from spoofed time back to normal time."""
+    fixed_time = datetime(2020, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+    claims = JWTClaims()
+    claims.spoof_time(fixed_time)
+    assert claims.now == fixed_time
+
+    # Revert
+    claims.spoof_time(None)
+    current_actual_time = datetime.now(UTC).replace(microsecond=0)
+    time_diff = abs((claims.now - current_actual_time).total_seconds())
+    assert time_diff < 2  # Within 2 seconds tolerance


### PR DESCRIPTION
It is now possible to spoof time for any `JWTBaseModel` model. Closes #46 

```python
from datetime import datetime, UTC
from superjwt import JWTClaims
from superjwt.exceptions import TokenExpiredError

claims = JWTClaims().with_expiration(minutes=30)

isnotnow: datetime = datetime(2042, 1, 1, 20, 42, 59, tzinfo=UTC)
claims.spoof_time(isnotnow)

try:
    claims.revalidate()  # fails
except TokenExpiredError:
    print("expired!!!")

claims.now_ = None
claims.revalidate()  # passes
```