### PR TITLE
🔢 Timestamp serialization int / float mode

### DIFF
--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -94,17 +94,34 @@ class HttpsUrl(HttpUrl):
     _constraints = UrlConstraints(max_length=2083, allowed_schemes=["https"])
 
 
+DEFAULT_JWTDATETIME_FORCE_INT: bool = True
+
+
 class JWTBaseModel(BaseModel):
     model_config = {"extra": "allow", "revalidate_instances": "always"}
 
     internal__now: Annotated[datetime | None, Field(exclude=True, repr=False)] = None
+    internal__jwtdatetime_force_int: Annotated[bool, Field(exclude=True, repr=False)] = (
+        DEFAULT_JWTDATETIME_FORCE_INT
+    )
 
     def revalidate(self) -> None:
         """Re-validate the pydantic instance against its own model."""
         self.model_validate(self)
 
     def to_dict(self) -> dict[str, Any]:
-        return self.model_dump(exclude_none=True)
+        return self.model_dump(
+            exclude_none=True,
+            context={"jwtdatetime_force_int": self.internal__jwtdatetime_force_int},
+        )
+
+    def force_jwtdatetime_to_int(self) -> None:
+        """Force JWTDatetime fields to be serialized as integers (seconds since epoch)."""
+        self.internal__jwtdatetime_force_int = True
+
+    def force_jwtdatetime_to_float(self) -> None:
+        """Force JWTDatetime fields to be serialized as floats (seconds since epoch with microseconds)."""
+        self.internal__jwtdatetime_force_int = False
 
     def spoof_time(self, set_now: datetime | None) -> None:
         """Spoof the current time for testing purposes. Set to None to disable spoofing."""
@@ -180,17 +197,31 @@ class JOSEHeader(JWTBaseModel):
         return self
 
 
-def remove_subsecond(dt: datetime) -> datetime:
-    return dt.replace(microsecond=0)
+def serialize_jwtdatetime_timestamp(
+    value: datetime | int | float, info: ValidationInfo
+) -> int | float:
+    jwtdatetime_force_int = getattr(info, "context", {}).get(
+        "jwtdatetime_force_int", DEFAULT_JWTDATETIME_FORCE_INT
+    )
+    if jwtdatetime_force_int is True:
+        return serialize_jwtdatetime_timestamp_to_int(value)
+    elif jwtdatetime_force_int is False:
+        return serialize_jwtdatetime_timestamp_to_float(value)
+    raise ValueError("Invalid timestamp config type")
 
 
-def serialize_second_timestamps(value: datetime | int | float) -> int:
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
+def serialize_jwtdatetime_timestamp_to_int(value: datetime | int | float) -> int:
+    if isinstance(value, (int, float)):
         return int(value)
-    if isinstance(value, datetime):
+    else:
         return int(value.timestamp())
+
+
+def serialize_jwtdatetime_timestamp_to_float(value: datetime | int | float) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    else:
+        return value.timestamp()
 
 
 def check_future_dates(value: datetime | None, info: ValidationInfo) -> datetime | None:
@@ -208,8 +239,17 @@ def check_future_dates(value: datetime | None, info: ValidationInfo) -> datetime
 
 JWTDatetime = Annotated[
     datetime,
-    AfterValidator(remove_subsecond),
-    PlainSerializer(serialize_second_timestamps),
+    PlainSerializer(serialize_jwtdatetime_timestamp),
+]
+
+JWTDatetimeInt = Annotated[
+    datetime,
+    PlainSerializer(serialize_jwtdatetime_timestamp_to_int),
+]
+
+JWTDatetimeFloat = Annotated[
+    datetime,
+    PlainSerializer(serialize_jwtdatetime_timestamp_to_float),
 ]
 
 
@@ -255,17 +295,17 @@ class JWTClaims(JWTClaimsModel):
 
     @property
     def now(self) -> datetime:
-        """Get the current time"""
+        """Get the current time."""
         if self.internal__now is None:
-            return datetime.now(UTC).replace(microsecond=0)
-        return self.internal__now.replace(microsecond=0)
+            return datetime.now(UTC)
+        return self.internal__now
 
     @staticmethod
     def get_now(info: ValidationInfo) -> datetime:
         now = info.data["internal__now"]
         if now is None:
-            return datetime.now(UTC).replace(microsecond=0)
-        return now.replace(microsecond=0)
+            return datetime.now(UTC)
+        return now
 
     @model_validator(mode="after")
     def check_exp_after_nbf(self) -> Self:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,14 +31,38 @@ class JWTCustomClaims(JWTClaims):
 
 
 def check_claims_instance(
-    claim_before: JWTCustomClaims, claim_after: JWTCustomClaims
+    claim_before: JWTCustomClaims,
+    claim_after: JWTCustomClaims,
+    jwtdatetime_force_int: bool,
 ) -> None:
     assert claim_after.iss == claim_before.iss
     assert claim_after.sub == claim_before.sub
     assert claim_after.aud is None
-    assert claim_after.iat == claim_before.iat
-    assert claim_after.nbf == claim_before.nbf
-    assert claim_after.exp == claim_before.exp
+
+    # Compare timestamps based on serialization mode
+    if jwtdatetime_force_int is False:
+        # Float mode: microseconds must be preserved exactly
+        if claim_after.iat is not None and claim_before.iat is not None:
+            assert float(claim_after.iat.timestamp()) == float(
+                claim_before.iat.timestamp()
+            )
+        if claim_after.nbf is not None and claim_before.nbf is not None:
+            assert float(claim_after.nbf.timestamp()) == float(
+                claim_before.nbf.timestamp()
+            )
+        if claim_after.exp is not None and claim_before.exp is not None:
+            assert float(claim_after.exp.timestamp()) == float(
+                claim_before.exp.timestamp()
+            )
+    else:
+        # Int mode: compare at second-level precision (microseconds truncated)
+        if claim_after.iat is not None and claim_before.iat is not None:
+            assert int(claim_after.iat.timestamp()) == int(claim_before.iat.timestamp())
+        if claim_after.nbf is not None and claim_before.nbf is not None:
+            assert int(claim_after.nbf.timestamp()) == int(claim_before.nbf.timestamp())
+        if claim_after.exp is not None and claim_before.exp is not None:
+            assert int(claim_after.exp.timestamp()) == int(claim_before.exp.timestamp())
+
     assert claim_after.jti is None
     assert claim_after.user_id == claim_before.user_id
     assert claim_after.optional_id is None

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,14 +1,15 @@
 from datetime import datetime, timedelta
+from typing import Any
 
 import pydantic
 import pytest
-from superjwt.definitions import (
-    JWTClaims,
-)
+from superjwt.definitions import JWTClaims
 from superjwt.exceptions import (
     TokenExpiredError,
     TokenNotYetValidError,
 )
+
+from .conftest import JWTCustomClaims, check_claims_instance
 
 
 try:
@@ -22,24 +23,24 @@ except ImportError:
 
 def test_validate_exp_with_datetime_input():
     """Test validate_exp field validator with datetime input."""
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC)
 
     # exp=None
     claims_none = JWTClaims.model_validate({"exp": None})
     assert claims_none.exp is None
 
     # exp in future
-    future_exp = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=1)
+    future_exp = now + timedelta(hours=1)
     claims = JWTClaims(exp=future_exp)
     assert claims.exp == future_exp
 
-    # exp equal to now (expired)
-    current_time = datetime.now(UTC).replace(microsecond=0)
+    # exp equal to now (expired) - subtract small amount to ensure it's in the past
+    current_time = now - timedelta(seconds=1)
     with pytest.raises(TokenExpiredError):
         JWTClaims(exp=current_time)
 
     # exp in past (expired)
-    past_exp = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+    past_exp = now - timedelta(hours=1)
     with pytest.raises(TokenExpiredError):
         JWTClaims(exp=past_exp)
 
@@ -60,21 +61,17 @@ def test_validate_exp_with_datetime_input():
 
 def test_validate_exp_with_timestamp_input():
     """Test validate_exp field validator with int/float timestamp input."""
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC)
 
     # exp as int timestamp
     future_timestamp_int = int((datetime.now(UTC) + timedelta(hours=1)).timestamp())
     claims = JWTClaims(exp=future_timestamp_int)  # type: ignore[arg-type]
-    assert claims.exp == datetime.fromtimestamp(future_timestamp_int, tz=UTC).replace(
-        microsecond=0
-    )
+    assert claims.exp == datetime.fromtimestamp(future_timestamp_int, tz=UTC)
 
     # exp as float timestamp
     future_timestamp_float = (datetime.now(UTC) + timedelta(hours=1)).timestamp()
     claims_float = JWTClaims(exp=future_timestamp_float)  # type: ignore[arg-type]
-    assert claims_float.exp == datetime.fromtimestamp(
-        future_timestamp_float, tz=UTC
-    ).replace(microsecond=0)
+    assert claims_float.exp == datetime.fromtimestamp(future_timestamp_float, tz=UTC)
 
     # exp in past
     past_timestamp = int((datetime.now(UTC) - timedelta(hours=1)).timestamp())
@@ -85,9 +82,7 @@ def test_validate_exp_with_timestamp_input():
     iat_time = now - timedelta(days=1)
     exp_timestamp_int = int((now + timedelta(hours=1)).timestamp())
     claims_with_iat = JWTClaims(iat=iat_time, exp=exp_timestamp_int)  # type: ignore[arg-type]
-    assert claims_with_iat.exp == datetime.fromtimestamp(
-        exp_timestamp_int, tz=UTC
-    ).replace(microsecond=0)
+    assert claims_with_iat.exp == datetime.fromtimestamp(exp_timestamp_int, tz=UTC)
 
     # exp <= iat
     iat_timestamp = now
@@ -101,56 +96,55 @@ def test_validate_exp_with_timestamp_input():
 
 def test_validate_nbf_with_datetime_input():
     """Test validate_nbf field validator with datetime input."""
+    now = datetime.now(UTC)
+
     # nbf in past
-    past_nbf = datetime.now(UTC).replace(microsecond=0) - timedelta(hours=1)
+    past_nbf = now - timedelta(hours=1)
     claims = JWTClaims(nbf=past_nbf)
     assert claims.nbf == past_nbf
 
-    # nbf equal to now
-    current_time = datetime.now(UTC).replace(microsecond=0)
-    claims_now = JWTClaims(nbf=current_time)
-    assert claims_now.nbf == current_time
-
-    # nbf in future
-    future_nbf = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=1)
+    # nbf far in future (should raise error)
+    future_nbf = now + timedelta(hours=1)
     with pytest.raises(TokenNotYetValidError):
         JWTClaims(nbf=future_nbf)
 
     # nbf <= iat
-    now = datetime.now(UTC).replace(microsecond=0)
     with pytest.raises(
         pydantic.ValidationError,
         match="'nbf' claim must be strictly greater than 'iat' claim",
     ):
         JWTClaims(iat=now, nbf=now)
 
-    # Test with_issued_at() preserving exp delta (lines 305-306 in definitions.py)
+    # Test with_issued_at()
     claims_with_both = JWTClaims(
         iat=now - timedelta(hours=2), exp=now + timedelta(hours=2)
     )
     updated = claims_with_both.with_issued_at()
-    assert updated.iat is not None and updated.iat >= now  # New iat is current time
+    # Compare timestamps since microseconds might differ slightly
+    assert updated.iat is not None and int(updated.iat.timestamp()) == int(
+        datetime.now(UTC).timestamp()
+    )
     assert updated.exp is not None
-    assert (updated.exp - updated.iat) == timedelta(hours=4)  # Delta preserved
+    # Delta should be exactly 4 hours, allow for microsecond precision differences
+    delta = updated.exp - updated.iat
+    assert (
+        abs(delta.total_seconds() - timedelta(hours=4).total_seconds()) < 0.001
+    )  # Within 1ms tolerance
 
 
 def test_validate_nbf_with_timestamp_input():
     """Test validate_nbf field validator with int/float timestamp input."""
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC)
 
     # nbf as int timestamp
     past_timestamp_int = int((datetime.now(UTC) - timedelta(hours=1)).timestamp())
     claims = JWTClaims(nbf=past_timestamp_int)  # type: ignore[arg-type]
-    assert claims.nbf == datetime.fromtimestamp(past_timestamp_int, tz=UTC).replace(
-        microsecond=0
-    )
+    assert claims.nbf == datetime.fromtimestamp(past_timestamp_int, tz=UTC)
 
     # nbf as float timestamp
     past_timestamp_float = (datetime.now(UTC) - timedelta(hours=1)).timestamp()
     claims_float = JWTClaims(nbf=past_timestamp_float)  # type: ignore[arg-type]
-    assert claims_float.nbf == datetime.fromtimestamp(
-        past_timestamp_float, tz=UTC
-    ).replace(microsecond=0)
+    assert claims_float.nbf == datetime.fromtimestamp(past_timestamp_float, tz=UTC)
 
     # nbf in future
     future_timestamp = int((datetime.now(UTC) + timedelta(hours=1)).timestamp())
@@ -177,7 +171,7 @@ def test_check_exp_after_nbf_model_validator():
     assert claims.nbf < claims.exp
 
     # nbf >= exp with iat=None
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC)
 
     # Make both in future but inverted: nbf > exp
     future_nbf = now + timedelta(days=2)
@@ -322,6 +316,157 @@ def test_spoof_time_revert_to_normal():
 
     # Revert
     claims.spoof_time(None)
-    current_actual_time = datetime.now(UTC).replace(microsecond=0)
+    current_actual_time = datetime.now(UTC)
     time_diff = abs((claims.now - current_actual_time).total_seconds())
     assert time_diff < 2  # Within 2 seconds tolerance
+
+
+# Timestamp serialization tests (int vs float mode)
+
+
+def test_default_int_serialization(jwt, secret_key):
+    """Test that default serialization uses int (microseconds truncated)."""
+    now = datetime.now(UTC)
+    claims = JWTClaims(iat=now, exp=now + timedelta(hours=1))
+
+    # Verify default is int
+    assert claims.internal__jwtdatetime_force_int is True
+
+    # Encode and decode
+    token = jwt.encode(claims, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+
+    # Check payload has int timestamps
+    assert isinstance(decoded.payload["iat"], int)
+    assert isinstance(decoded.payload["exp"], int)
+
+    # Verify microseconds were truncated
+    assert decoded.payload["iat"] == int(now.timestamp())
+    assert decoded.payload["exp"] == int((now + timedelta(hours=1)).timestamp())
+
+
+def test_float_serialization_preserves_microseconds(jwt, secret_key):
+    """Test that float serialization preserves microseconds."""
+    now = datetime.now(UTC)
+    claims = JWTClaims(iat=now, exp=now + timedelta(hours=1))
+
+    # Switch to float mode
+    claims.force_jwtdatetime_to_float()
+
+    # Encode and decode
+    token = jwt.encode(claims, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+
+    # Check payload has float timestamps
+    assert isinstance(decoded.payload["iat"], float)
+    assert isinstance(decoded.payload["exp"], float)
+
+    # Verify microseconds were preserved
+    assert decoded.payload["iat"] == now.timestamp()
+    assert decoded.payload["exp"] == (now + timedelta(hours=1)).timestamp()
+
+    # Verify exact microsecond match
+    assert abs(decoded.payload["iat"] - now.timestamp()) < 1e-6
+    assert abs(decoded.payload["exp"] - (now + timedelta(hours=1)).timestamp()) < 1e-6
+
+
+def test_custom_claims_int_mode(jwt, secret_key):
+    """Test custom claims with int serialization mode."""
+    now = datetime.now(UTC)
+    claims_before = JWTCustomClaims(
+        iss="issuer",
+        sub="user123",
+        user_id="value",
+        iat=now,
+        exp=now + timedelta(days=1),
+        past_date=now - timedelta(days=1),
+        future_date=now + timedelta(days=2),
+    )
+
+    # Default int mode
+    assert claims_before.internal__jwtdatetime_force_int is True
+
+    # Encode and decode
+    token = jwt.encode(claims_before, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    claims_after = JWTCustomClaims(**decoded.payload)
+
+    # Check with int precision
+    check_claims_instance(claims_before, claims_after, jwtdatetime_force_int=True)
+
+
+def test_custom_claims_float_mode(jwt, secret_key):
+    """Test custom claims with float serialization mode."""
+    now = datetime.now(UTC)
+    claims_before = JWTCustomClaims(
+        iss="issuer",
+        sub="user123",
+        user_id="value",
+        iat=now,
+        exp=now + timedelta(days=1),
+        past_date=now - timedelta(days=1),
+        future_date=now + timedelta(days=2),
+    )
+
+    # Switch to float mode
+    claims_before.force_jwtdatetime_to_float()
+
+    # Encode and decode
+    token = jwt.encode(claims_before, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    claims_after = JWTCustomClaims(**decoded.payload)
+
+    # Check with float precision - should preserve microseconds
+    check_claims_instance(claims_before, claims_after, jwtdatetime_force_int=False)
+
+
+def test_microseconds_actually_preserved_in_float_mode(jwt, secret_key):
+    """Explicitly verify microseconds are preserved in float mode."""
+    # Create datetime with specific microseconds
+    dt_with_microseconds = datetime(2026, 1, 3, 12, 30, 45, 123456, tzinfo=UTC)
+
+    claims = JWTClaims(iat=dt_with_microseconds)
+    claims.force_jwtdatetime_to_float()
+
+    # Encode and decode
+    token = jwt.encode(claims, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+
+    # Reconstruct datetime from float timestamp
+    decoded_dt = datetime.fromtimestamp(decoded.payload["iat"], tz=UTC)
+
+    # Verify microseconds match
+    assert decoded_dt.microsecond == 123456
+    assert decoded_dt == dt_with_microseconds
+
+
+def test_microseconds_truncated_in_int_mode(jwt, secret_key):
+    """Explicitly verify microseconds are truncated in int mode."""
+    # Create datetime with specific microseconds
+    dt_with_microseconds = datetime(2026, 1, 3, 12, 30, 45, 123456, tzinfo=UTC)
+
+    claims = JWTClaims(iat=dt_with_microseconds)
+    # Default int mode
+
+    # Encode and decode
+    token = jwt.encode(claims, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+
+    # Reconstruct datetime from int timestamp
+    decoded_dt = datetime.fromtimestamp(decoded.payload["iat"], tz=UTC)
+
+    # Verify microseconds were lost
+    assert decoded_dt.microsecond == 0
+    assert decoded_dt != dt_with_microseconds
+    # But should match at second level
+    assert int(decoded_dt.timestamp()) == int(dt_with_microseconds.timestamp())
+
+
+def test_unserialized_datetime(claims_dict: dict[str, Any]):
+    claims = JWTClaims.model_construct(**claims_dict)
+
+    assert int(claims.exp) == int(claims_dict["exp"])  # type: ignore
+
+    claims.force_jwtdatetime_to_float()
+    claims_dict = claims.to_dict()
+    assert abs(claims.exp - claims_dict["exp"]) < 1e-6

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -10,6 +10,8 @@ from superjwt.definitions import (
     JWTBaseModel,
     JWTClaims,
     JWTDatetime,
+    JWTDatetimeFloat,
+    JWTDatetimeInt,
     JWTValidationModelConfig,
     Validation,
     check_future_dates,
@@ -153,7 +155,7 @@ def test_encode_decode_pydantic_claims(
     compact = jwt.encode(claims, secret_key, "HS256").compact
     decoded_claims = JWTCustomClaims(**jwt.decode(compact, secret_key, "HS256").payload)
 
-    check_claims_instance(claims, decoded_claims)
+    check_claims_instance(claims, decoded_claims, jwtdatetime_force_int=True)
 
     # test non compliant claims
     claims = JWTCustomClaims(**claims_dict)
@@ -196,7 +198,7 @@ def test_hmac_algorithms(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
         token = jwt.encode(claims, secret_key, alg).compact
         decoded_claims = JWTCustomClaims(**jwt.decode(token, secret_key, alg).payload)
 
-        check_claims_instance(claims, decoded_claims)
+        check_claims_instance(claims, decoded_claims, jwtdatetime_force_int=True)
 
 
 def test_encode_decode_claims_validation_disabled(
@@ -228,11 +230,11 @@ def test_encode_decode_claims_validation_disabled(
     decoded_claims = JWTCustomClaims(
         **decoded_claims.to_dict()
     )  # ensure validation + serialization for datetime
-    check_claims_instance(claims, decoded_claims)
+    check_claims_instance(claims, decoded_claims, jwtdatetime_force_int=True)
 
 
 def test_encode_decode_claims_dict_validation_disabled(
-    jwt: JWT, claims_dict: dict[str, Any], secret_key_random: str
+    jwt: JWT, claims_dict: dict[str, Any], exp: float, secret_key_random: str
 ):
     # prepare an invalid claims dict
     unvalidated_claims_dict = claims_dict.copy()
@@ -268,9 +270,9 @@ def test_encode_decode_claims_dict_validation_disabled(
     decoded_claims.sub = claims_dict["sub"]  # fix type for sub to match original claims
     decoded_claims = JWTCustomClaims(
         **decoded_claims.to_dict()
-    )  # ensure validation + serialization for datetime
+    )  # ensure validation + serialization for datetime as int timestamp
     claims = JWTCustomClaims(**claims_dict)  # the original claims data
-    check_claims_instance(claims, decoded_claims)
+    check_claims_instance(claims, decoded_claims, jwtdatetime_force_int=True)
 
 
 def test_custom_claims_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
@@ -525,13 +527,13 @@ def test_not_yet_valid_token(jwt: JWT, secret_key: str):
 
 def test_exp_nbf_validation_in_jwt_workflow(jwt: JWT, secret_key: str):
     """Test exp/nbf validators in full encode/decode workflow."""
-    now = datetime.now(UTC).replace(microsecond=0)
+    now = datetime.now(UTC)
 
     # Test with claims containing all time fields using model_construct
     # (normal validation impossible when iat is present with nbf/exp)
-    past_iat = datetime.now(UTC).replace(microsecond=0) - timedelta(days=365)
-    past_nbf = datetime.now(UTC).replace(microsecond=0) - timedelta(days=180)
-    past_exp = datetime.now(UTC).replace(microsecond=0) - timedelta(days=90)
+    past_iat = datetime.now(UTC) - timedelta(days=365)
+    past_nbf = datetime.now(UTC) - timedelta(days=180)
+    past_exp = datetime.now(UTC) - timedelta(days=90)
     valid_claims = JWTClaims.model_construct(
         sub="user123", iat=past_iat, nbf=past_nbf, exp=past_exp
     )
@@ -953,3 +955,108 @@ def test_detached_payload_conflict(jwt: JWT, secret_key: str):
             "HS256",
             with_detached_payload={"sub": "test", "user_id": "123"},
         )
+
+
+def test_timestamp_switching_modes(jwt, secret_key):
+    """Test that switching serialization mode works correctly."""
+    now = datetime.now(UTC)
+    claims = JWTClaims(iat=now)
+
+    # Encode with int mode
+    claims.force_jwtdatetime_to_int()
+    token_int = jwt.encode(claims, secret_key, "HS256")
+    decoded_int = jwt.decode(token_int.compact, secret_key, "HS256")
+    assert isinstance(decoded_int.payload["iat"], int)
+    assert decoded_int.payload["iat"] == int(now.timestamp())
+
+    # Encode with float mode
+    claims.force_jwtdatetime_to_float()
+    token_float = jwt.encode(claims, secret_key, "HS256")
+    decoded_float = jwt.decode(token_float.compact, secret_key, "HS256")
+    assert isinstance(decoded_float.payload["iat"], float)
+    assert decoded_float.payload["iat"] == now.timestamp()
+
+    # Invalid mode
+    claims.internal__jwtdatetime_force_int = "invalid"  # type: ignore
+    with pytest.raises(ValueError, match="Invalid timestamp config type"):
+        jwt.encode(claims, secret_key, "HS256")
+
+
+def test_mixed_datetime_serialization_types(jwt, secret_key):
+    """Test custom claims with mixed JWTDatetime, JWTDatetimeInt, and JWTDatetimeFloat."""
+
+    class CustomMixedClaims(JWTClaims):
+        # exp redefined as required
+        exp: JWTDatetime = pydantic.Field(default=...)
+
+        # nbf redefined as a required JWTDatetimeInt (always int)
+        nbf: JWTDatetimeInt = pydantic.Field(default=...)
+
+        # custom field with JWTDatetimeFloat (always float)
+        custom_time: JWTDatetimeFloat = pydantic.Field(default=...)
+
+    now = datetime.now(UTC)
+
+    # Create instance with specific microseconds to test precision
+    exp_time = datetime(2026, 6, 1, 12, 30, 45, 123456, tzinfo=UTC)
+    nbf_time = datetime(2025, 12, 1, 10, 15, 30, 654321, tzinfo=UTC)
+    custom_time = datetime(2026, 3, 15, 8, 45, 22, 987654, tzinfo=UTC)
+
+    claims = CustomMixedClaims(
+        iat=now - timedelta(hours=1),
+        exp=exp_time,
+        nbf=nbf_time,
+        custom_time=custom_time,
+    )
+    assert claims.internal__jwtdatetime_force_int is True
+
+    token = jwt.encode(claims, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, "HS256")
+
+    # exp should be int (because flag is True and it's JWTDatetime)
+    assert isinstance(decoded.payload["exp"], int)
+    assert decoded.payload["exp"] == int(exp_time.timestamp())
+
+    # nbf should ALWAYS be int (JWTDatetimeInt ignores flag)
+    assert isinstance(decoded.payload["nbf"], int)
+    assert decoded.payload["nbf"] == int(nbf_time.timestamp())
+
+    # custom_time should ALWAYS be float (JWTDatetimeFloat ignores flag)
+    assert isinstance(decoded.payload["custom_time"], float)
+    assert abs(decoded.payload["custom_time"] - custom_time.timestamp()) < 1e-6
+
+    # Now switch to float mode
+    claims.force_jwtdatetime_to_float()
+    assert claims.internal__jwtdatetime_force_int is False
+
+    # Encode and decode again
+    token2 = jwt.encode(claims, secret_key, "HS256")
+    decoded2 = jwt.decode(token2.compact, secret_key, "HS256")
+
+    # exp should now be float (because flag is False and it's JWTDatetime)
+    assert isinstance(decoded2.payload["exp"], float)
+    assert abs(decoded2.payload["exp"] - exp_time.timestamp()) < 1e-6
+
+    # nbf should STILL be int (JWTDatetimeInt always ignores flag)
+    assert isinstance(decoded2.payload["nbf"], int)
+    assert decoded2.payload["nbf"] == int(nbf_time.timestamp())
+
+    # custom_time should STILL be float (JWTDatetimeFloat always ignores flag)
+    assert isinstance(decoded2.payload["custom_time"], float)
+    assert abs(decoded2.payload["custom_time"] - custom_time.timestamp()) < 1e-6
+
+    # Switch back to int mode
+    claims.force_jwtdatetime_to_int()
+    assert claims.internal__jwtdatetime_force_int is True
+
+    # Encode and decode one more time
+    token3 = jwt.encode(claims, secret_key, "HS256")
+    decoded3 = jwt.decode(token3.compact, secret_key, "HS256")
+
+    # exp should be back to int
+    assert isinstance(decoded3.payload["exp"], int)
+    assert decoded3.payload["exp"] == int(exp_time.timestamp())
+
+    # nbf and custom_time behavior unchanged
+    assert isinstance(decoded3.payload["nbf"], int)
+    assert isinstance(decoded3.payload["custom_time"], float)


### PR DESCRIPTION
- choose default behavior for timestamp serialization for `JWTDatetime` fields (`JWTBaseModel.force_jwtdatetime_to_float()` , `JWTBaseModel.force_jwtdatetime_to_int()`). Default is int.
- add `JWTDatetimeInt` and `JWTDatetimeFloat` pydantic field types that bypass automatic desired timestamp serialization.