### PR TITLE
feat: leeway support + strict time integrity

### DIFF
--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Annotated, Any, Literal
 
 from pydantic import (
-    AfterValidator,
     BaseModel,
     Field,
     HttpUrl,
@@ -31,6 +30,7 @@ from superjwt.exceptions import (
     TokenNotYetValidError,
 )
 from superjwt.keys import BaseKey, NoneKey, OctKey
+from superjwt.utils import delta_datetime_timestamp
 
 
 try:
@@ -224,19 +224,6 @@ def serialize_jwtdatetime_timestamp_to_float(value: datetime | int | float) -> f
         return value.timestamp()
 
 
-def check_future_dates(value: datetime | None, info: ValidationInfo) -> datetime | None:
-    iat = info.data.get("iat")
-    if value is None or iat is None:
-        return value
-    if not isinstance(iat, datetime) or not isinstance(value, datetime):
-        raise TypeError("Invalid type for datetime comparison")
-    if value <= iat:
-        raise ValueError(
-            f"'{info.field_name}' claim must be strictly greater than 'iat' claim"
-        )
-    return value
-
-
 JWTDatetime = Annotated[
     datetime,
     PlainSerializer(serialize_jwtdatetime_timestamp),
@@ -275,12 +262,10 @@ class JWTClaimsModel(JWTBaseModel):
         Field(
             description="not before time - the time before which the JWT must not be accepted"
         ),
-        AfterValidator(check_future_dates),
     ] = None
     exp: Annotated[
         JWTDatetime | None,
         Field(description="expiration time - the time after which the JWT expires"),
-        AfterValidator(check_future_dates),
     ] = None
     jti: Annotated[
         str | None,
@@ -293,6 +278,9 @@ class JWTClaims(JWTClaimsModel):
     JWT standard claims as per RFC 7519.
     """
 
+    internal__leeway: Annotated[float, Field(exclude=True, repr=False)] = 5.0
+    internal__allow_future_iat: Annotated[bool, Field(exclude=True, repr=False)] = True
+
     @property
     def now(self) -> datetime:
         """Get the current time."""
@@ -300,41 +288,45 @@ class JWTClaims(JWTClaimsModel):
             return datetime.now(UTC)
         return self.internal__now
 
-    @staticmethod
-    def get_now(info: ValidationInfo) -> datetime:
-        now = info.data["internal__now"]
-        if now is None:
-            return datetime.now(UTC)
-        return now
+    def set_leeway(self, leeway_seconds: float) -> None:
+        """Set the leeway (in seconds) for time-based claim validations."""
+        if leeway_seconds < 0:
+            raise ValueError("Leeway must be a non-negative float")
+        self.internal__leeway = leeway_seconds
+
+    def allow_future_iat(self) -> None:
+        """Disable the check that 'iat' claim is not in the future."""
+        self.internal__allow_future_iat = False
+
+    def disallow_future_iat(self) -> None:
+        """Enable the check that 'iat' claim is not in the future."""
+        self.internal__allow_future_iat = True
 
     @model_validator(mode="after")
-    def check_exp_after_nbf(self) -> Self:
-        if self.exp is not None and self.nbf is not None:
-            if self.nbf >= self.exp:
-                raise ValueError("'nbf' claim must be strictly less than 'exp' claim")
+    def validate_time_integrity(self) -> Self:
+        # check nbf >= iat
+        if self.nbf is not None and self.iat is not None:
+            if self.nbf < self.iat:
+                raise ValueError(
+                    "'nbf' claim must be greater than or equal to 'iat' claim"
+                )
+
+        # check iat <= now, modulo leeway
+        if self.iat is not None and self.internal__allow_future_iat:
+            if delta_datetime_timestamp(self.iat, self.now) > self.internal__leeway:
+                raise ValueError("'iat' claim must not be in the future")
+
+        # check nbf <= now, modulo leeway
+        if self.nbf is not None:
+            if delta_datetime_timestamp(self.nbf, self.now) > self.internal__leeway:
+                raise TokenNotYetValidError()
+
+        # check exp > now, modulo leeway
+        if self.exp is not None:
+            if delta_datetime_timestamp(self.now, self.exp) >= self.internal__leeway:
+                raise TokenExpiredError()
+
         return self
-
-    @field_validator("exp")
-    @classmethod
-    def validate_exp(
-        cls, value: datetime | None, info: ValidationInfo
-    ) -> datetime | None:
-        if value is None:
-            return value
-        if value <= cls.get_now(info):
-            raise TokenExpiredError()
-        return value
-
-    @field_validator("nbf")
-    @classmethod
-    def validate_nbf(
-        cls, value: datetime | None, info: ValidationInfo
-    ) -> datetime | None:
-        if value is None:
-            return value
-        if value > cls.get_now(info):
-            raise TokenNotYetValidError()
-        return value
 
     def with_issued_at(self) -> Self:
         """Return a new JWTClaims instance with the 'iat' claim set to current time."""
@@ -350,16 +342,24 @@ class JWTClaims(JWTClaimsModel):
     def with_expiration(
         self,
         *,
-        minutes: int = 0,
-        hours: int = 0,
-        days: int = 0,
+        minutes: int | None = None,
+        hours: int | None = None,
+        days: int | None = None,
     ) -> Self:
         """Return a new JWTClaims instance with the 'exp' claim set to current time plus the specified delta."""
-        if minutes < 0 or hours < 0 or days < 0:
-            raise ValueError(
-                "Expiration minutes, hours, and days must be non-negative integers"
-            )
-        exp_time = self.now + timedelta(minutes=minutes, hours=hours, days=days)
+
+        for delta in (minutes, hours, days):
+            if delta is not None and not isinstance(delta, (int, float)):
+                raise TypeError(
+                    "Expiration minutes, hours, and days must be valid numbers"
+                )
+            if delta is not None and delta <= 0:
+                raise ValueError(
+                    "Expiration minutes, hours, and days must be positive numbers"
+                )
+        exp_time = self.now + timedelta(
+            minutes=minutes or 0, hours=hours or 0, days=days or 0
+        )
 
         # case iat was already set
         if self.iat is not None:

--- a/superjwt/utils.py
+++ b/superjwt/utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import re
+from datetime import datetime
 
 
 def as_bytes(s: str | bytes) -> bytes:
@@ -78,3 +79,20 @@ _SSH_KEY_FORMATS = (
 
 def is_ssh_key(key: bytes) -> bool:
     return key.startswith(_SSH_KEY_FORMATS)
+
+
+def delta_datetime_timestamp(
+    dt1: datetime | float | int, dt2: datetime | float | int
+) -> float:
+    """Return the absolute difference between two datetime objects or timestamps."""
+    if isinstance(dt1, datetime):
+        ts1 = dt1.timestamp()
+    else:
+        ts1 = float(dt1)
+
+    if isinstance(dt2, datetime):
+        ts2 = dt2.timestamp()
+    else:
+        ts2 = float(dt2)
+
+    return ts1 - ts2

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Any
 
-import pydantic
 import pytest
 from superjwt.definitions import JWTClaims
 from superjwt.exceptions import (
@@ -21,177 +20,372 @@ except ImportError:
     UTC = timezone.utc
 
 
-def test_validate_exp_with_datetime_input():
-    """Test validate_exp field validator with datetime input."""
-    now = datetime.now(UTC)
+class TestTimeIntegrityValidation:
+    """Test suite for the validate_time_integrity model validator."""
 
-    # exp=None
-    claims_none = JWTClaims.model_validate({"exp": None})
-    assert claims_none.exp is None
+    def test_all_none_claims(self):
+        """Test that claims with no time fields pass validation."""
+        claims = JWTClaims()
+        assert claims.iat is None
+        assert claims.nbf is None
+        assert claims.exp is None
 
-    # exp in future
-    future_exp = now + timedelta(hours=1)
-    claims = JWTClaims(exp=future_exp)
-    assert claims.exp == future_exp
+    def test_exp_in_future_valid(self):
+        """Test that exp in the future is valid."""
+        now = datetime.now(UTC)
+        claims = JWTClaims(exp=now + timedelta(hours=1))
+        assert claims.exp == now + timedelta(hours=1)
 
-    # exp equal to now (expired) - subtract small amount to ensure it's in the past
-    current_time = now - timedelta(seconds=1)
-    with pytest.raises(TokenExpiredError):
-        JWTClaims(exp=current_time)
+    def test_exp_in_past_raises_error(self):
+        """Test that exp in the past raises TokenExpiredError."""
+        now = datetime.now(UTC)
+        with pytest.raises(TokenExpiredError):
+            JWTClaims(exp=now - timedelta(hours=1))
 
-    # exp in past (expired)
-    past_exp = now - timedelta(hours=1)
-    with pytest.raises(TokenExpiredError):
-        JWTClaims(exp=past_exp)
+    def test_exp_equal_to_now_valid(self):
+        """Test that exp equal to now is valid (within default leeway of 5s)."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        claims = JWTClaims.model_construct(exp=fixed_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.exp == fixed_time
 
-    # exp > iat
-    iat_time = now - timedelta(days=1)
-    exp_time = now + timedelta(hours=1)
-    claims_with_iat = JWTClaims(iat=iat_time, exp=exp_time)
-    assert claims_with_iat.exp == exp_time
-    assert claims_with_iat.iat == iat_time
+    def test_exp_with_leeway(self):
+        """Test that exp validation respects leeway."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
-    # exp <= iat
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="'exp' claim must be strictly greater than 'iat' claim",
-    ):
-        JWTClaims(iat=now, exp=now)
+        # exp is 4.9 seconds in the past, within 5 second leeway (should pass)
+        exp_time = fixed_time - timedelta(seconds=4.9)
+        claims = JWTClaims.model_construct(exp=exp_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.exp == exp_time
+
+        # exp is exactly at leeway boundary (should fail, >= check)
+        exp_at_leeway = fixed_time - timedelta(seconds=5)
+        claims2 = JWTClaims.model_construct(exp=exp_at_leeway)
+        claims2.spoof_time(fixed_time)
+        with pytest.raises(TokenExpiredError):
+            claims2.revalidate()
+
+        # exp is beyond leeway boundary (should fail)
+        exp_beyond_leeway = fixed_time - timedelta(seconds=6)
+        claims3 = JWTClaims.model_construct(exp=exp_beyond_leeway)
+        claims3.spoof_time(fixed_time)
+        with pytest.raises(TokenExpiredError):
+            claims3.revalidate()
+
+    def test_nbf_in_past_valid(self):
+        """Test that nbf in the past is valid."""
+        now = datetime.now(UTC)
+        claims = JWTClaims(nbf=now - timedelta(hours=1))
+        assert claims.nbf == now - timedelta(hours=1)
+
+    def test_nbf_in_future_raises_error(self):
+        """Test that nbf in the future raises TokenNotYetValidError."""
+        now = datetime.now(UTC)
+        with pytest.raises(TokenNotYetValidError):
+            JWTClaims(nbf=now + timedelta(hours=1))
+
+    def test_nbf_equal_to_now_valid(self):
+        """Test that nbf equal to now is valid (within leeway)."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        claims = JWTClaims.model_construct(nbf=fixed_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.nbf == fixed_time
+
+    def test_nbf_with_leeway(self):
+        """Test that nbf validation respects leeway."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+        # nbf is 3 seconds in the future, but leeway is 5 seconds (default)
+        nbf_time = fixed_time + timedelta(seconds=3)
+        claims = JWTClaims.model_construct(nbf=nbf_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.nbf == nbf_time
+
+        # nbf is exactly at leeway boundary (should pass, > check)
+        nbf_at_leeway = fixed_time + timedelta(seconds=5)
+        claims2 = JWTClaims.model_construct(nbf=nbf_at_leeway)
+        claims2.spoof_time(fixed_time)
+        claims2.revalidate()
+        assert claims2.nbf == nbf_at_leeway
+
+        # nbf is beyond leeway boundary (should fail)
+        nbf_beyond_leeway = fixed_time + timedelta(seconds=6)
+        claims3 = JWTClaims.model_construct(nbf=nbf_beyond_leeway)
+        claims3.spoof_time(fixed_time)
+        with pytest.raises(TokenNotYetValidError):
+            claims3.revalidate()
+
+    def test_iat_in_past_valid(self):
+        """Test that iat in the past is valid."""
+        now = datetime.now(UTC)
+        claims = JWTClaims(iat=now - timedelta(hours=1))
+        assert claims.iat == now - timedelta(hours=1)
+
+    def test_iat_equal_to_now_valid(self):
+        """Test that iat equal to now is valid."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        claims = JWTClaims.model_construct(iat=fixed_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == fixed_time
+
+    def test_iat_in_future_raises_error(self):
+        """Test that iat in the future raises ValueError when check_consistent_iat is True."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        iat_future = fixed_time + timedelta(hours=1)
+        claims = JWTClaims.model_construct(iat=iat_future)
+        claims.spoof_time(fixed_time)
+        with pytest.raises(ValueError, match="'iat' claim must not be in the future"):
+            claims.revalidate()
+
+    def test_iat_in_future_allowed_when_check_disabled(self):
+        """Test that iat in the future is allowed when disable_iat_consistency_check()."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        iat_future = fixed_time + timedelta(hours=1)
+        claims = JWTClaims.model_construct(iat=iat_future)
+        claims.allow_future_iat()
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == iat_future
+        claims.disallow_future_iat()
+        with pytest.raises(ValueError, match="'iat' claim must not be in the future"):
+            claims.revalidate()
+
+    def test_iat_with_leeway(self):
+        """Test that iat validation respects leeway."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+        # iat is 3 seconds in the future, but leeway is 5 seconds (default)
+        iat_time = fixed_time + timedelta(seconds=3)
+        claims = JWTClaims.model_construct(iat=iat_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == iat_time
+
+        # iat is exactly at leeway boundary (should pass, > check)
+        iat_at_leeway = fixed_time + timedelta(seconds=5)
+        claims2 = JWTClaims.model_construct(iat=iat_at_leeway)
+        claims2.spoof_time(fixed_time)
+        claims2.revalidate()
+        assert claims2.iat == iat_at_leeway
+
+        # iat is beyond leeway boundary (should fail)
+        iat_beyond_leeway = fixed_time + timedelta(seconds=6)
+        claims3 = JWTClaims.model_construct(iat=iat_beyond_leeway)
+        claims3.spoof_time(fixed_time)
+        with pytest.raises(ValueError, match="'iat' claim must not be in the future"):
+            claims3.revalidate()
+
+    def test_nbf_iat_relationship_valid(self):
+        """Test that nbf >= iat is valid."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        iat_time = fixed_time - timedelta(days=2)
+        nbf_time = fixed_time - timedelta(days=1)
+
+        claims = JWTClaims.model_construct(iat=iat_time, nbf=nbf_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == iat_time
+        assert claims.nbf == nbf_time
+
+    def test_nbf_equal_to_iat_valid(self):
+        """Test that nbf equal to iat is valid."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        time_value = fixed_time - timedelta(days=1)
+
+        claims = JWTClaims.model_construct(iat=time_value, nbf=time_value)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == time_value
+        assert claims.nbf == time_value
+
+    def test_nbf_less_than_iat_raises_error(self):
+        """Test that nbf < iat raises ValueError."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        iat_time = fixed_time - timedelta(days=1)
+        nbf_time = fixed_time - timedelta(days=2)  # nbf before iat
+
+        claims = JWTClaims.model_construct(iat=iat_time, nbf=nbf_time)
+        claims.spoof_time(fixed_time)
+        with pytest.raises(
+            ValueError, match="'nbf' claim must be greater than or equal to 'iat' claim"
+        ):
+            claims.revalidate()
+
+    def test_all_three_claims_valid(self):
+        """Test valid configuration with iat, nbf, and exp."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        iat_time = fixed_time - timedelta(days=2)
+        nbf_time = fixed_time - timedelta(days=1)
+        exp_time = fixed_time + timedelta(days=1)
+
+        claims = JWTClaims.model_construct(iat=iat_time, nbf=nbf_time, exp=exp_time)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.iat == iat_time
+        assert claims.nbf == nbf_time
+        assert claims.exp == exp_time
+
+    def test_complex_scenario_with_timestamps(self):
+        """Test complex scenario with int timestamps."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+        iat_ts = int((fixed_time - timedelta(days=1)).timestamp())
+        nbf_ts = int((fixed_time - timedelta(hours=1)).timestamp())
+        exp_ts = int((fixed_time + timedelta(days=1)).timestamp())
+
+        claims = JWTClaims.model_construct(iat=iat_ts, nbf=nbf_ts, exp=exp_ts)  # type: ignore
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+
+        assert claims.iat is not None
+        assert claims.nbf is not None
+        assert claims.exp is not None
+
+    def test_custom_leeway(self):
+        """Test that custom leeway values work correctly."""
+        fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+        # Set custom leeway to 10 seconds, exp is 8 seconds in past (within leeway)
+        exp_time = fixed_time - timedelta(seconds=8)
+        claims = JWTClaims.model_construct(exp=exp_time, internal__leeway=10.0)
+        claims.spoof_time(fixed_time)
+        claims.revalidate()
+        assert claims.exp == exp_time
+
+        # exp is at the custom leeway boundary (should fail)
+        exp_time2 = fixed_time - timedelta(seconds=10)
+        claims2 = JWTClaims.model_construct(exp=exp_time2, internal__leeway=10.0)
+        claims2.spoof_time(fixed_time)
+        with pytest.raises(TokenExpiredError):
+            claims2.revalidate()
+
+        # exp is beyond custom leeway (should fail)
+        exp_time3 = fixed_time - timedelta(seconds=11)
+        claims3 = JWTClaims.model_construct(exp=exp_time3, internal__leeway=10.0)
+        claims3.spoof_time(fixed_time)
+        with pytest.raises(TokenExpiredError):
+            claims3.revalidate()
+
+    def test_set_leeway_method(self):
+        """Test the set_leeway() method."""
+        claims = JWTClaims()
+
+        # Test setting valid positive leeway
+        claims.set_leeway(10.5)
+        assert claims.internal__leeway == 10.5
+
+        # Test setting leeway to zero (should be valid)
+        claims.set_leeway(0)
+        assert claims.internal__leeway == 0
+
+        # Test that negative leeway raises ValueError
+        with pytest.raises(ValueError, match="Leeway must be a non-negative float"):
+            claims.set_leeway(-1)
 
 
-def test_validate_exp_with_timestamp_input():
-    """Test validate_exp field validator with int/float timestamp input."""
-    now = datetime.now(UTC)
-
-    # exp as int timestamp
-    future_timestamp_int = int((datetime.now(UTC) + timedelta(hours=1)).timestamp())
-    claims = JWTClaims(exp=future_timestamp_int)  # type: ignore[arg-type]
-    assert claims.exp == datetime.fromtimestamp(future_timestamp_int, tz=UTC)
-
-    # exp as float timestamp
-    future_timestamp_float = (datetime.now(UTC) + timedelta(hours=1)).timestamp()
-    claims_float = JWTClaims(exp=future_timestamp_float)  # type: ignore[arg-type]
-    assert claims_float.exp == datetime.fromtimestamp(future_timestamp_float, tz=UTC)
-
-    # exp in past
-    past_timestamp = int((datetime.now(UTC) - timedelta(hours=1)).timestamp())
-    with pytest.raises(TokenExpiredError):
-        JWTClaims(exp=past_timestamp)  # type: ignore[arg-type]
-
-    # exp > iat
-    iat_time = now - timedelta(days=1)
-    exp_timestamp_int = int((now + timedelta(hours=1)).timestamp())
-    claims_with_iat = JWTClaims(iat=iat_time, exp=exp_timestamp_int)  # type: ignore[arg-type]
-    assert claims_with_iat.exp == datetime.fromtimestamp(exp_timestamp_int, tz=UTC)
-
-    # exp <= iat
-    iat_timestamp = now
-    exp_equal_iat = int(now.timestamp())
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="'exp' claim must be strictly greater than 'iat' claim",
-    ):
-        JWTClaims(iat=iat_timestamp, exp=exp_equal_iat)  # type: ignore[arg-type]
+# ============================================================================
+# JWTClaims Expiration / IssuedAt Method Tests
+# ============================================================================
 
 
-def test_validate_nbf_with_datetime_input():
-    """Test validate_nbf field validator with datetime input."""
-    now = datetime.now(UTC)
+def test_with_issued_at_basic():
+    """Test with_issued_at() method sets iat to current time."""
+    fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
-    # nbf in past
-    past_nbf = now - timedelta(hours=1)
-    claims = JWTClaims(nbf=past_nbf)
-    assert claims.nbf == past_nbf
+    claims = JWTClaims()
+    claims.spoof_time(fixed_time)
+    updated = claims.with_issued_at()
 
-    # nbf far in future (should raise error)
-    future_nbf = now + timedelta(hours=1)
-    with pytest.raises(TokenNotYetValidError):
-        JWTClaims(nbf=future_nbf)
-
-    # nbf <= iat
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="'nbf' claim must be strictly greater than 'iat' claim",
-    ):
-        JWTClaims(iat=now, nbf=now)
-
-    # Test with_issued_at()
-    claims_with_both = JWTClaims(
-        iat=now - timedelta(hours=2), exp=now + timedelta(hours=2)
-    )
-    updated = claims_with_both.with_issued_at()
-    # Compare timestamps since microseconds might differ slightly
-    assert updated.iat is not None and int(updated.iat.timestamp()) == int(
-        datetime.now(UTC).timestamp()
-    )
-    assert updated.exp is not None
-    # Delta should be exactly 4 hours, allow for microsecond precision differences
-    delta = updated.exp - updated.iat
-    assert (
-        abs(delta.total_seconds() - timedelta(hours=4).total_seconds()) < 0.001
-    )  # Within 1ms tolerance
+    assert updated.iat == fixed_time
 
 
-def test_validate_nbf_with_timestamp_input():
-    """Test validate_nbf field validator with int/float timestamp input."""
-    now = datetime.now(UTC)
+def test_with_issued_at_preserves_exp_delta():
+    """Test that with_issued_at() preserves the delta between iat and exp."""
+    fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
-    # nbf as int timestamp
-    past_timestamp_int = int((datetime.now(UTC) - timedelta(hours=1)).timestamp())
-    claims = JWTClaims(nbf=past_timestamp_int)  # type: ignore[arg-type]
-    assert claims.nbf == datetime.fromtimestamp(past_timestamp_int, tz=UTC)
+    # Create claims with iat 2 days ago and exp 2 days in future (4 day delta)
+    old_iat = fixed_time - timedelta(days=2)
+    old_exp = fixed_time + timedelta(days=2)
 
-    # nbf as float timestamp
-    past_timestamp_float = (datetime.now(UTC) - timedelta(hours=1)).timestamp()
-    claims_float = JWTClaims(nbf=past_timestamp_float)  # type: ignore[arg-type]
-    assert claims_float.nbf == datetime.fromtimestamp(past_timestamp_float, tz=UTC)
+    claims = JWTClaims.model_construct(iat=old_iat, exp=old_exp)
+    claims.spoof_time(fixed_time)
+    claims.revalidate()
 
-    # nbf in future
-    future_timestamp = int((datetime.now(UTC) + timedelta(hours=1)).timestamp())
-    with pytest.raises(TokenNotYetValidError):
-        JWTClaims(nbf=future_timestamp)  # type: ignore[arg-type]
+    updated = claims.with_issued_at()
 
-    # nbf <= iat
-    iat_timestamp = now
-    nbf_equal_iat = int(now.timestamp())
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="'nbf' claim must be strictly greater than 'iat' claim",
-    ):
-        JWTClaims(iat=iat_timestamp, nbf=nbf_equal_iat)  # type: ignore[arg-type]
+    # iat should now be fixed_time
+    assert updated.iat == fixed_time
+    # exp should be fixed_time + 4 days
+    assert updated.exp == fixed_time + timedelta(days=4)
 
 
-def test_check_exp_after_nbf_model_validator():
-    """Test check_exp_after_nbf model validator ensures nbf < exp."""
-    # nbf < exp
-    nbf_ts = int((datetime.now(UTC) - timedelta(days=90)).timestamp())
-    exp_ts = int((datetime.now(UTC) + timedelta(days=90)).timestamp())
-    claims = JWTClaims(nbf=nbf_ts, exp=exp_ts)  # type: ignore[arg-type]
-    assert claims.nbf is not None and claims.exp is not None
-    assert claims.nbf < claims.exp
+def test_with_expiration_basic():
+    """Test with_expiration() method sets exp relative to now."""
+    fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
-    # nbf >= exp with iat=None
-    now = datetime.now(UTC)
+    claims = JWTClaims()
+    claims.spoof_time(fixed_time)
+    updated = claims.with_expiration(hours=2)
 
-    # Make both in future but inverted: nbf > exp
-    future_nbf = now + timedelta(days=2)
-    future_exp = now + timedelta(days=1)
-
-    # This will fail on nbf field validator (nbf in future)
-    with pytest.raises(TokenNotYetValidError):
-        JWTClaims(nbf=future_nbf, exp=future_exp, iat=None)
-
-    # Try both in past but inverted
-    past_nbf = now - timedelta(days=1)
-    past_exp = now - timedelta(days=2)
-
-    # This will fail on exp field validator (exp in past)
-    with pytest.raises(TokenExpiredError):
-        JWTClaims(nbf=past_nbf, exp=past_exp, iat=None)
+    assert updated.exp == fixed_time + timedelta(hours=2)
+    assert updated.iat is None  # iat not set when it wasn't already
 
 
-def test_spoof_time_with_method():
-    """Test time spoofing using the spoof_time() method."""
+def test_with_expiration_updates_iat():
+    """Test that with_expiration() updates iat when it was already set."""
+    fixed_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+    old_iat = fixed_time - timedelta(days=1)
+
+    claims = JWTClaims.model_construct(iat=old_iat)
+    claims.spoof_time(fixed_time)
+    claims.revalidate()
+
+    updated = claims.with_expiration(days=1)
+
+    # iat should be updated to current time
+    assert updated.iat == fixed_time
+    # exp should be fixed_time + 1 day
+    assert updated.exp == fixed_time + timedelta(days=1)
+
+
+def test_with_expiration_negative_raises_error():
+    """Test that with_expiration() raises error for negative values."""
+    claims = JWTClaims()
+
+    with pytest.raises(ValueError, match="positive numbers"):
+        claims.with_expiration(hours=-1)
+
+    with pytest.raises(ValueError, match="positive numbers"):
+        claims.with_expiration(days=-1)
+
+    with pytest.raises(ValueError, match="positive numbers"):
+        claims.with_expiration(minutes=-1)
+
+
+def test_with_expiration_invalid_type_raises_error():
+    """Test that with_expiration() raises TypeError for invalid types."""
+    claims = JWTClaims()
+
+    with pytest.raises(TypeError, match="must be valid numbers"):
+        claims.with_expiration(hours="not a number")  # type: ignore
+
+    with pytest.raises(TypeError, match="must be valid numbers"):
+        claims.with_expiration(minutes=[1, 2, 3])  # type: ignore
+
+
+# ============================================================================
+# Spoof Time Tests
+# ============================================================================
+
+
+def test_spoof_time_method():
+    """Test spoofing time with spoof_time() method."""
     fixed_time = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
 
     claims = JWTClaims()
@@ -199,35 +393,19 @@ def test_spoof_time_with_method():
     assert claims.now == fixed_time
     assert claims.internal__now == fixed_time
 
-    # Test that exp validation uses spoofed time
-    claims_with_exp = JWTClaims.model_construct(exp=fixed_time + timedelta(hours=1))
-    claims_with_exp.spoof_time(fixed_time)
-    claims_with_exp.revalidate()
-    assert claims_with_exp.exp == fixed_time + timedelta(hours=1)
 
-    # Setting exp equal to fixed_time should raise TokenExpiredError
-    expired_claims = JWTClaims.model_construct(exp=fixed_time)
-    expired_claims.spoof_time(fixed_time)
-    with pytest.raises(TokenExpiredError):
-        expired_claims.revalidate()
-
-    # Revert to normal time
-    claims.spoof_time(None)
-    assert claims.now != fixed_time  # Should be close to actual current time
-
-
-def test_spoof_time_with_exp_validation():
-    """Test exp validation with spoofed time."""
+def test_spoof_time_with_validation():
+    """Test that validation uses spoofed time."""
     fixed_time = datetime(2025, 3, 10, 15, 0, 0, tzinfo=UTC)
 
-    # Test valid exp in the future (relative to spoofed time)
+    # Test exp validation with spoofed time
     future_exp = fixed_time + timedelta(days=30)
     claims = JWTClaims.model_construct(exp=future_exp)
     claims.spoof_time(fixed_time)
     claims.revalidate()
     assert claims.exp == future_exp
 
-    # Test expired token (exp in the past relative to spoofed time)
+    # Test expired token relative to spoofed time
     past_exp = fixed_time - timedelta(days=1)
     past_claims = JWTClaims.model_construct(exp=past_exp)
     past_claims.spoof_time(fixed_time)
@@ -235,79 +413,8 @@ def test_spoof_time_with_exp_validation():
         past_claims.revalidate()
 
 
-def test_spoof_time_with_nbf_validation():
-    """Test nbf validation with spoofed time."""
-    fixed_time = datetime(2025, 4, 20, 8, 0, 0, tzinfo=UTC)
-
-    # Test valid nbf in the past (relative to spoofed time)
-    past_nbf = fixed_time - timedelta(hours=2)
-    claims = JWTClaims.model_construct(nbf=past_nbf)
-    claims.spoof_time(fixed_time)
-    claims.revalidate()
-    assert claims.nbf == past_nbf
-
-    # Test nbf equal to spoofed time
-    claims_now = JWTClaims.model_construct(nbf=fixed_time)
-    claims_now.spoof_time(fixed_time)
-    claims_now.revalidate()
-    assert claims_now.nbf == fixed_time
-
-    # Test nbf in the future (relative to spoofed time)
-    future_nbf = fixed_time + timedelta(hours=1)
-    future_claims = JWTClaims.model_construct(nbf=future_nbf)
-    future_claims.spoof_time(fixed_time)
-    with pytest.raises(TokenNotYetValidError):
-        future_claims.revalidate()
-
-
-def test_spoof_time_with_iat_exp_relationship():
-    """Test iat and exp relationship with spoofed time."""
-    fixed_time = datetime(2025, 2, 14, 14, 0, 0, tzinfo=UTC)
-
-    # Create claims with iat in past and exp in future (relative to spoofed time)
-    iat_time = fixed_time - timedelta(days=1)
-    exp_time = fixed_time + timedelta(days=1)
-
-    claims = JWTClaims.model_construct(iat=iat_time, exp=exp_time)
-    claims.spoof_time(fixed_time)
-    claims.revalidate()
-
-    assert claims.iat == iat_time
-    assert claims.exp == exp_time
-
-    # Test with_issued_at() uses spoofed time
-    claims_with_iat = JWTClaims()
-    claims_with_iat.spoof_time(fixed_time)
-    updated_claims = claims_with_iat.with_issued_at()
-    assert updated_claims.iat == fixed_time
-
-
-def test_spoof_time_with_expiration_method():
-    """Test with_expiration() method with spoofed time."""
-    fixed_time = datetime(2025, 5, 1, 12, 0, 0, tzinfo=UTC)
-
-    claims = JWTClaims()
-    claims.spoof_time(fixed_time)
-
-    # Add expiration relative to spoofed time
-    claims_with_exp = claims.with_expiration(hours=2)
-    expected_exp = fixed_time + timedelta(hours=2)
-
-    assert claims_with_exp.exp == expected_exp
-    # Note: with_expiration() only sets iat if it was already set
-    # Since we started with empty claims, iat remains None
-    assert claims_with_exp.iat is None
-
-    # Test with iat already set
-    claims_with_iat = JWTClaims(iat=fixed_time - timedelta(days=1))
-    claims_with_iat.spoof_time(fixed_time)
-    claims_with_both = claims_with_iat.with_expiration(hours=2)
-    assert claims_with_both.exp == expected_exp
-    assert claims_with_both.iat == fixed_time
-
-
-def test_spoof_time_revert_to_normal():
-    """Test reverting from spoofed time back to normal time."""
+def test_spoof_time_revert():
+    """Test reverting from spoofed time back to normal."""
     fixed_time = datetime(2020, 1, 1, 0, 0, 0, tzinfo=UTC)
 
     claims = JWTClaims()
@@ -321,7 +428,9 @@ def test_spoof_time_revert_to_normal():
     assert time_diff < 2  # Within 2 seconds tolerance
 
 
-# Timestamp serialization tests (int vs float mode)
+# ============================================================================
+# Timestamp Serialization Tests
+# ============================================================================
 
 
 def test_default_int_serialization(jwt, secret_key):
@@ -463,10 +572,11 @@ def test_microseconds_truncated_in_int_mode(jwt, secret_key):
 
 
 def test_unserialized_datetime(claims_dict: dict[str, Any]):
+    """Test datetime serialization in to_dict()."""
     claims = JWTClaims.model_construct(**claims_dict)
 
     assert int(claims.exp) == int(claims_dict["exp"])  # type: ignore
 
     claims.force_jwtdatetime_to_float()
-    claims_dict = claims.to_dict()
-    assert abs(claims.exp - claims_dict["exp"]) < 1e-6
+    claims_dict_float = claims.to_dict()
+    assert abs(claims.exp - claims_dict_float["exp"]) < 1e-6

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Any
 
 import pydantic
 import pytest
@@ -14,7 +14,6 @@ from superjwt.definitions import (
     JWTDatetimeInt,
     JWTValidationModelConfig,
     Validation,
-    check_future_dates,
 )
 from superjwt.exceptions import (
     ClaimsValidationError,
@@ -137,14 +136,11 @@ def test_with_expiration_negative():
 
 
 def test_rewrite_incorrect_exp_type():
-    # custom datetime claim set to invalid type should be handled correctly
-
     class JWTIncorrectExpClaim(JWTClaims):
-        iat: JWTDatetime = datetime.now(UTC)
-        exp: Annotated[Any, pydantic.AfterValidator(check_future_dates)]  # type: ignore
+        exp: JWTDatetime  # type: ignore
 
-    with pytest.raises(TypeError):
-        JWTIncorrectExpClaim(exp=True)
+    with pytest.raises(pydantic.ValidationError):
+        JWTIncorrectExpClaim(exp=True)  # type: ignore
 
 
 def test_encode_decode_pydantic_claims(
@@ -998,8 +994,8 @@ def test_mixed_datetime_serialization_types(jwt, secret_key):
     now = datetime.now(UTC)
 
     # Create instance with specific microseconds to test precision
-    exp_time = datetime(2026, 6, 1, 12, 30, 45, 123456, tzinfo=UTC)
-    nbf_time = datetime(2025, 12, 1, 10, 15, 30, 654321, tzinfo=UTC)
+    exp_time = now + timedelta(hours=10, minutes=30, seconds=15, microseconds=123456)
+    nbf_time = now
     custom_time = datetime(2026, 3, 15, 8, 45, 22, 987654, tzinfo=UTC)
 
     claims = CustomMixedClaims(


### PR DESCRIPTION
- add leeway for `'iat'`, `'nbf'`, `'exp'` validation against _now_. Default leeway = 5s. Can be changed with `JWTClaims.set_leeway()`.
- By default, `'iat'` consistency will be checked: if `'iat'` in the future, raise `ValueError`. Can be disabled with `JWTClaims.disallow_future_iat()`, can be reenabled with `JWTClaims.allow_future_iat()`.