### PR TITLE
refactor: Alg enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ SuperJWT makes it easy to encode and decode JWT tokens with automatic validation
 Encode manually your claims from a `dict`. During decoding, validate your JWT content against the standard JWT claims.
 
 ```python
-from superjwt import JWTClaims, encode, decode
+from superjwt import Alg, JWTClaims, encode, decode
 
 secret_key = "your-secret-key-of-len-32-bytes!"
 
-compact: bytes = encode({"iss": "my-app", "sub": "John Doe"}, secret_key, "HS256")
+compact: bytes = encode({"iss": "my-app", "sub": "John Doe"}, secret_key, Alg.HS256)
 #> b'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 #   .eyJpc3MiOiJteS1hcHAiLCJzdWIiOiJKb2huIERvZSJ9
 #   .HwnUqTLFAMzNkMrokd0aI7c-zSJJpSVXMrYIhUyWe4s'
-decoded: dict = decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+decoded: dict = decode(compact, secret_key, Alg.HS256, claims_validation=JWTClaims)
 #> {'iss': 'my-app', 'sub': 'John Doe'}
 ```
 
@@ -70,7 +70,7 @@ Define dynamically your claims with Pydantic and easily include `'iat'` (Issued 
 Validate your JWT content automatically during encoding and decoding. 
 
 ```python
-from superjwt import JWTClaims, encode, decode
+from superjwt import Alg, JWTClaims, encode, decode
 
 secret_key = "your-secret-key-of-len-32-bytes!"
 
@@ -80,11 +80,11 @@ claims = (
     .with_expiration(minutes=15)
 )
 
-compact: bytes = encode(claims, secret_key, "HS256")
+compact: bytes = encode(claims, secret_key, Alg.HS256)
 #> b'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 #   .eyJpc3MiOiJteS1hcHAiLCJzdWIiOiJKb2huIERvZSIsImlhdCI6MTc2NzAyNzQ4MywiZXhwIjoxNzY3MDI4MzgzfQ
 #   .ZXxZT8VzL8IPTov-enslCh57S2M5fQBtqULZx5zEAm8'
-decoded: dict = decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+decoded: dict = decode(compact, secret_key, Alg.HS256, claims_validation=JWTClaims)
 #> {'iss': 'my-app', 'sub': 'John Doe', 'iat': 1767027483, 'exp': 1767028383}
 ```
 
@@ -97,7 +97,7 @@ from typing import Annotated
 from uuid import UUID
 
 from pydantic import AfterValidator, Field
-from superjwt import JWTClaims, Validation, decode, encode
+from superjwt import Alg, JWTClaims, Validation, decode, encode
 from superjwt.exceptions import ClaimsValidationError
 
 secret_key = "your-secret-key-of-len-32-bytes!"
@@ -117,8 +117,8 @@ claims = (
     MyJWTClaims(sub=123, user_id="b2a4c791-2cf4-4e41-9a20-8532129ff47c")
     .with_expiration(minutes=15)
 )
-compact = encode(claims, secret_key, "HS256")
-decoded = decode(compact, secret_key, "HS256", claims_validation=MyJWTClaims)
+compact = encode(claims, secret_key, Alg.HS256)
+decoded = decode(compact, secret_key, Alg.HS256, claims_validation=MyJWTClaims)
 #> {'sub': 123, 'exp': 1767027591, 'user_id': 'b2a4c791-2cf4-4e41-9a20-8532129ff47c'}
 ```
 
@@ -134,10 +134,10 @@ invalid_claims = (
 
 # disable claims default validation to create an invalid token
 invalid_compact = encode(
-    invalid_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+    invalid_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
 )
 try:
-    decode(invalid_compact, secret_key, "HS256", claims_validation=MyJWTClaims)
+    decode(invalid_compact, secret_key, Alg.HS256, claims_validation=MyJWTClaims)
 except ClaimsValidationError as e:
     print("Claims validation error:", e)
 #> Claims validation error: Claims validation failed
@@ -156,7 +156,7 @@ except ClaimsValidationError as e:
 from superjwt import JWSToken, inspect
 
 compact = (
-    b"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+    b"eyJhbGciOiJOb05lIiwidHlwIjoiSldUIn0"
     b"."
     b"eyJjYW5fSV90cnVzdF95b3UiOiJubyJ9"
     b"."
@@ -169,7 +169,7 @@ token.payload
 #> {'can_I_trust_you': 'no'}
 
 token.headers
-#> {'alg': 'none', 'typ': 'JWT'}
+#> {'alg': 'NoNe', 'typ': 'JWT'}
 ```
 
 

--- a/superjwt/__init__.py
+++ b/superjwt/__init__.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from superjwt._version import __version__
 from superjwt.definitions import (
-    Algorithm,
+    Alg,
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
@@ -19,6 +19,7 @@ from superjwt.keys import BaseKey
 
 __all__ = [
     "JWT",
+    "Alg",
     "JOSEHeader",
     "JWTClaims",
     "JWTDatetime",
@@ -34,7 +35,7 @@ __all__ = [
 def encode(
     claims: JWTBaseModel | dict[str, Any] | None,
     key: str | bytes | BaseKey,
-    algorithm: Algorithm,
+    algorithm: Alg | str,
     *,
     headers: JOSEHeader | dict[str, Any] | None = None,
     detach_payload: bool = False,
@@ -88,7 +89,7 @@ def encode(
 def decode(
     compact: bytes | str,
     key: str | bytes | BaseKey,
-    algorithm: Algorithm,
+    algorithm: Alg | str,
     *,
     with_detached_payload: JWTClaims | dict[str, Any] | None = None,
     claims_validation: type[JWTBaseModel]

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -45,42 +45,66 @@ except ImportError:
 
 MAX_TOKEN_BYTES: int = 16 * 1024  # 16 KB
 
-Algorithm = Literal[
-    "HS256",
-    "HS384",
-    "HS512",
-    "RS256",
-    "RS384",
-    "RS512",
-    "PS256",
-    "PS384",
-    "PS512",
-    "ES256",
-    "ES256K",
-    "ES384",
-    "ES512",
-    "Ed25519",
-    "Ed448",
-]
+
+class Alg(str, Enum):
+    """JWS/JWT Algorithm names with associated implementation instances."""
+
+    HS256 = "HS256"
+    HS384 = "HS384"
+    HS512 = "HS512"
+    RS256 = "RS256"
+    RS384 = "RS384"
+    RS512 = "RS512"
+    PS256 = "PS256"
+    PS384 = "PS384"
+    PS512 = "PS512"
+    ES256 = "ES256"
+    ES256K = "ES256K"
+    ES384 = "ES384"
+    ES512 = "ES512"
+    Ed25519 = "Ed25519"
+    Ed448 = "Ed448"
+
+    def get_instance(self) -> BaseJWSAlgorithm:
+        instance = ALG_INSTANCES.get(self.value)
+        if instance is None:
+            raise AlgorithmNotSupportedError(
+                f"JWS Algorithm '{self.value}' is not yet implemented"
+            )
+        return instance
+
+    @classmethod
+    def get_instance_by_name(cls, name: str) -> BaseJWSAlgorithm:
+        if name not in ALG_INSTANCES:
+            raise InvalidAlgorithmError(
+                f"Algorithm '{name}' is not a valid JWS algorithm"
+            )
+        instance = ALG_INSTANCES[name]
+        if instance is None:
+            raise AlgorithmNotSupportedError(
+                f"JWS Algorithm '{name}' is not yet implemented"
+            )
+        return instance
 
 
-class AlgorithmInstance(Enum):
-    none = NoneAlgorithm()
-    HS256 = HS256Algorithm()
-    HS384 = HS384Algorithm()
-    HS512 = HS512Algorithm()
-    RS256 = None  # Placeholder
-    RS384 = None  # Placeholder
-    RS512 = None  # Placeholder
-    PS256 = None  # Placeholder
-    PS384 = None  # Placeholder
-    PS512 = None  # Placeholder
-    ES256 = None  # Placeholder
-    ES256K = None  # Placeholder
-    ES384 = None  # Placeholder
-    ES512 = None  # Placeholder
-    Ed25519 = None  # Placeholder
-    Ed448 = None  # Placeholder
+ALG_INSTANCES: dict[str, BaseJWSAlgorithm | None] = {
+    "none": NoneAlgorithm(),
+    "HS256": HS256Algorithm(),
+    "HS384": HS384Algorithm(),
+    "HS512": HS512Algorithm(),
+    "RS256": None,  # Placeholder
+    "RS384": None,  # Placeholder
+    "RS512": None,  # Placeholder
+    "PS256": None,  # Placeholder
+    "PS384": None,  # Placeholder
+    "PS512": None,  # Placeholder
+    "ES256": None,  # Placeholder
+    "ES256K": None,  # Placeholder
+    "ES384": None,  # Placeholder
+    "ES512": None,  # Placeholder
+    "Ed25519": None,  # Placeholder
+    "Ed448": None,  # Placeholder
+}
 
 
 class Key(Enum):
@@ -134,7 +158,7 @@ class JOSEHeader(JWTBaseModel):
     _strict_crit_check: bool = False
 
     alg: Annotated[
-        Algorithm | Literal["none"],
+        Alg | Literal["none"] | str,
         Field(description="algorithm - the algorithm used to sign the JWT"),
     ]
 
@@ -158,8 +182,22 @@ class JOSEHeader(JWTBaseModel):
     ] = None
 
     @classmethod
-    def make_default(cls, algorithm: Algorithm) -> Self:
+    def make_default(cls, algorithm: Alg | str) -> Self:
         return cls(alg=algorithm, typ="JWT")
+
+    @field_validator("alg")
+    @classmethod
+    def validate_alg(cls, value: Alg | str) -> Alg | str:
+        """Validate that the algorithm is a valid algorithm name."""
+        # Get the string value (works for both Algorithm enum and str)
+        algo_str = value.value if isinstance(value, Alg) else value
+
+        # Check if it's a valid algorithm (including "none")
+        valid_algorithms = set(member.value for member in Alg) | {"none"}
+        if algo_str not in valid_algorithms:
+            raise ValueError(f"'{algo_str}' is not a valid algorithm")
+
+        return value
 
     @field_validator("crit")
     @classmethod
@@ -419,19 +457,16 @@ class JWSTokenLifeCycle(BaseModel):
     verified: JWSToken = JWSToken()
 
 
-def get_jws_algorithm(algorithm: Algorithm | Literal["none"]) -> BaseJWSAlgorithm:
-    if algorithm not in AlgorithmInstance.__members__:
-        raise InvalidAlgorithmError(
-            f"Algorithm '{algorithm}' is not a valid JWS algorithm"
-        )
-    if (algo_jws := getattr(AlgorithmInstance, algorithm).value) is None:
-        raise AlgorithmNotSupportedError(
-            f"JWS Algorithm '{algorithm}' is not yet implemented"
-        )
-    return algo_jws
+def get_jws_algorithm(algorithm: Alg | Literal["none"] | str) -> BaseJWSAlgorithm:
+    # Convert to algorithm instance
+    if isinstance(algorithm, Alg):
+        return algorithm.get_instance()
+    else:
+        # Handle string input (including "none")
+        return Alg.get_instance_by_name(algorithm)
 
 
-def make_key(algorithm: Algorithm | Literal["none"], key: str | bytes) -> BaseKey:
+def make_key(algorithm: Alg | Literal["none"] | str, key: str | bytes) -> BaseKey:
     key_type = get_jws_algorithm(algorithm).key_type
     return key_type.import_key(key)
 

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from superjwt.algorithms import BaseJWSAlgorithm, NoneAlgorithm
 from superjwt.definitions import (
     MAX_TOKEN_BYTES,
-    Algorithm,
+    Alg,
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
@@ -35,7 +35,7 @@ from superjwt.utils import as_bytes, urlsafe_b64decode, urlsafe_b64encode
 class JWS:
     def __init__(
         self,
-        algorithm: Algorithm | Literal["none"],
+        algorithm: Alg | Literal["none"] | str,
         max_token_bytes: int = MAX_TOKEN_BYTES,
         default_headers_validation: JWTValidationCfg = JWTHeadersDefaultValidationCfg,
     ):
@@ -75,7 +75,7 @@ class JWS:
 
         # prepare headers data and perform validation
         if headers is None:
-            headers = JOSEHeader.make_default(cast("Algorithm", self.algorithm.name))
+            headers = JOSEHeader.make_default(cast("Alg", self.algorithm.name))
         try:
             headers_dict = prepare_and_validate_data(
                 data=headers,

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 
 from superjwt.definitions import (
     MAX_TOKEN_BYTES,
-    Algorithm,
+    Alg,
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
@@ -46,7 +46,7 @@ class JWT:
         self,
         claims: JWTBaseModel | dict[str, Any] | None,
         key: str | bytes | BaseKey,
-        algorithm: Algorithm = "HS256",
+        algorithm: Alg | str,
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]
@@ -136,7 +136,7 @@ class JWT:
         self,
         compact: str | bytes,
         key: str | bytes | BaseKey,
-        algorithm: Algorithm = "HS256",
+        algorithm: Alg | str,
         *,
         with_detached_payload: JWTBaseModel | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 from pydantic import Field
-from superjwt.definitions import JWTClaims, JWTDatetime
+from superjwt.definitions import Alg, JWTClaims, JWTDatetime
 from superjwt.jws import JWS
 from superjwt.jwt import JWT
 
@@ -75,7 +75,7 @@ def jwt() -> JWT:
 
 @pytest.fixture
 def jws_HS256() -> JWS:  # noqa: N802
-    return JWS(algorithm="HS256")
+    return JWS(algorithm=Alg.HS256)
 
 
 @pytest.fixture

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -2,8 +2,10 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
-from superjwt.definitions import JWTClaims
+from superjwt.definitions import Alg, JWTClaims
 from superjwt.exceptions import (
+    AlgorithmNotSupportedError,
+    InvalidAlgorithmError,
     TokenExpiredError,
     TokenNotYetValidError,
 )
@@ -442,8 +444,8 @@ def test_default_int_serialization(jwt, secret_key):
     assert claims.internal__jwtdatetime_force_int is True
 
     # Encode and decode
-    token = jwt.encode(claims, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
 
     # Check payload has int timestamps
     assert isinstance(decoded.payload["iat"], int)
@@ -463,8 +465,8 @@ def test_float_serialization_preserves_microseconds(jwt, secret_key):
     claims.force_jwtdatetime_to_float()
 
     # Encode and decode
-    token = jwt.encode(claims, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
 
     # Check payload has float timestamps
     assert isinstance(decoded.payload["iat"], float)
@@ -496,8 +498,8 @@ def test_custom_claims_int_mode(jwt, secret_key):
     assert claims_before.internal__jwtdatetime_force_int is True
 
     # Encode and decode
-    token = jwt.encode(claims_before, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims_before, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
     claims_after = JWTCustomClaims(**decoded.payload)
 
     # Check with int precision
@@ -521,8 +523,8 @@ def test_custom_claims_float_mode(jwt, secret_key):
     claims_before.force_jwtdatetime_to_float()
 
     # Encode and decode
-    token = jwt.encode(claims_before, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims_before, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
     claims_after = JWTCustomClaims(**decoded.payload)
 
     # Check with float precision - should preserve microseconds
@@ -538,8 +540,8 @@ def test_microseconds_actually_preserved_in_float_mode(jwt, secret_key):
     claims.force_jwtdatetime_to_float()
 
     # Encode and decode
-    token = jwt.encode(claims, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
 
     # Reconstruct datetime from float timestamp
     decoded_dt = datetime.fromtimestamp(decoded.payload["iat"], tz=UTC)
@@ -558,8 +560,8 @@ def test_microseconds_truncated_in_int_mode(jwt, secret_key):
     # Default int mode
 
     # Encode and decode
-    token = jwt.encode(claims, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
 
     # Reconstruct datetime from int timestamp
     decoded_dt = datetime.fromtimestamp(decoded.payload["iat"], tz=UTC)
@@ -580,3 +582,42 @@ def test_unserialized_datetime(claims_dict: dict[str, Any]):
     claims.force_jwtdatetime_to_float()
     claims_dict_float = claims.to_dict()
     assert abs(claims.exp - claims_dict_float["exp"]) < 1e-6
+
+
+class TestAlgEnum:
+    """Test suite for the Alg enum methods."""
+
+    def test_get_instance_not_implemented(self):
+        """Test that get_instance() raises AlgorithmNotSupportedError for unimplemented algorithms."""
+        # RS256 is defined but not yet implemented (ALG_INSTANCES[RS256] = None)
+        with pytest.raises(
+            AlgorithmNotSupportedError, match=r"RS256.*not yet implemented"
+        ):
+            Alg.RS256.get_instance()
+
+    def test_get_instance_by_name_invalid_algorithm(self):
+        """Test that get_instance_by_name() raises InvalidAlgorithmError for invalid algorithm names."""
+        with pytest.raises(
+            InvalidAlgorithmError, match=r"INVALID.*not a valid JWS algorithm"
+        ):
+            Alg.get_instance_by_name("INVALID")
+
+    def test_get_instance_by_name_not_implemented(self):
+        """Test that get_instance_by_name() raises AlgorithmNotSupportedError for unimplemented algorithms."""
+        # PS256 is defined but not yet implemented (ALG_INSTANCES[PS256] = None)
+        with pytest.raises(
+            AlgorithmNotSupportedError, match=r"PS256.*not yet implemented"
+        ):
+            Alg.get_instance_by_name("PS256")
+
+    def test_get_instance_success(self):
+        """Test that get_instance() successfully returns an algorithm instance for implemented algorithms."""
+        instance = Alg.HS256.get_instance()
+        assert instance is not None
+        assert instance.__class__.__name__ == "HS256Algorithm"
+
+    def test_get_instance_by_name_success(self):
+        """Test that get_instance_by_name() successfully returns an algorithm instance for implemented algorithms."""
+        instance = Alg.get_instance_by_name("HS256")
+        assert instance is not None
+        assert instance.__class__.__name__ == "HS256Algorithm"

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,11 +1,12 @@
 import json
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pydantic
 import pytest
 from superjwt import decode, encode, inspect
 from superjwt.definitions import (
+    Alg,
     JOSEHeader,
     JWTBaseModel,
     JWTClaims,
@@ -33,9 +34,6 @@ from superjwt.utils import urlsafe_b64encode
 from tests.conftest import JWTCustomClaims, check_claims_instance
 
 
-if TYPE_CHECKING:
-    from superjwt.definitions import Algorithm
-
 try:
     from datetime import UTC
 except ImportError:
@@ -46,14 +44,15 @@ except ImportError:
 
 
 def test_encode_decode_default_claims(secret_key):
+    # Test with string for backward compatibility
     compact = encode(None, secret_key, "HS256")
     decoded_claims = decode(compact, secret_key, "HS256")
     assert decoded_claims == {}
 
 
 def test_encode_decode_dict_claims(claims_dict, secret_key):
-    compact = encode(claims_dict, secret_key, "HS256")
-    decoded_claims_dict = decode(compact, secret_key, "HS256")
+    compact = encode(claims_dict, secret_key, Alg.HS256)
+    decoded_claims_dict = decode(compact, secret_key, Alg.HS256)
 
     # standard claims
     assert decoded_claims_dict["iss"] == claims_dict["iss"]
@@ -93,25 +92,25 @@ def test_encode_decode_dict_custom_datetime_claim(secret_key):
 
     # cannot encode unserializable datetime
     with pytest.raises(TypeError):
-        encode({"custom_date": custom_dt_unserializable}, secret_key, "HS256")
+        encode({"custom_date": custom_dt_unserializable}, secret_key, Alg.HS256)
 
     # can encode serializable datetime string, this will not be serialized as a timestamp
     # unlike the standard datetime claims (iat, nbf, exp)
-    compact = encode({"custom_date": custom_dt_serializable_str}, secret_key, "HS256")
-    decoded = decode(compact, secret_key, "HS256")
+    compact = encode({"custom_date": custom_dt_serializable_str}, secret_key, Alg.HS256)
+    decoded = decode(compact, secret_key, Alg.HS256)
     assert decoded["custom_date"] == custom_dt_serializable_str
 
     # can encode integer timestamp
-    compact = encode({"custom_date": custom_dt_correct}, secret_key, "HS256")
-    decoded = decode(compact, secret_key, "HS256")
+    compact = encode({"custom_date": custom_dt_correct}, secret_key, Alg.HS256)
+    decoded = decode(compact, secret_key, Alg.HS256)
     assert decoded["custom_date"] == custom_dt_correct
 
 
 def test_add_iat_add_exp(secret_key):
     # custom datetime claim set to None should be handled correctly
     claims = JWTClaims().with_issued_at().with_expiration(minutes=30)
-    compact = encode(claims, secret_key, "HS256")
-    decoded = decode(compact, secret_key, "HS256")
+    compact = encode(claims, secret_key, Alg.HS256)
+    decoded = decode(compact, secret_key, Alg.HS256)
     assert "iat" in decoded
     assert "exp" in decoded
 
@@ -124,8 +123,8 @@ def test_empty_iat_with_exp(secret_key):
             "2042-04-02T00:42:42.123456+0000", "%Y-%m-%dT%H:%M:%S.%f%z"
         ),
     )
-    compact = encode(claims, secret_key, "HS256")
-    decoded = decode(compact, secret_key, "HS256")
+    compact = encode(claims, secret_key, Alg.HS256)
+    decoded = decode(compact, secret_key, Alg.HS256)
     assert "iat" not in decoded
 
 
@@ -148,8 +147,8 @@ def test_encode_decode_pydantic_claims(
 ):
     claims = JWTCustomClaims(**claims_dict)
 
-    compact = jwt.encode(claims, secret_key, "HS256").compact
-    decoded_claims = JWTCustomClaims(**jwt.decode(compact, secret_key, "HS256").payload)
+    compact = jwt.encode(claims, secret_key, Alg.HS256).compact
+    decoded_claims = JWTCustomClaims(**jwt.decode(compact, secret_key, Alg.HS256).payload)
 
     check_claims_instance(claims, decoded_claims, jwtdatetime_force_int=True)
 
@@ -157,38 +156,38 @@ def test_encode_decode_pydantic_claims(
     claims = JWTCustomClaims(**claims_dict)
     claims.aud = 123  # invalid type for aud  # type: ignore
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims, secret_key, "HS256")
+        jwt.encode(claims, secret_key, Alg.HS256)
 
     # test custom claims model validation
     claims = JWTCustomClaims(**claims_dict)
     # encoding valid
-    jws_token = jwt.encode(claims, secret_key, "HS256")
+    jws_token = jwt.encode(claims, secret_key, Alg.HS256)
     jws_token2 = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=JWTCustomClaims
+        claims, secret_key, Alg.HS256, claims_validation=JWTCustomClaims
     )
     assert jws_token.compact == jws_token2.compact
     # decoding
     claims.user_id = None  # invalid type for user_id  # type: ignore
     compact = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     # passes (validation with default JWTClaims)
-    jwt.decode(compact, secret_key, "HS256")
+    jwt.decode(compact, secret_key, Alg.HS256)
     # fails (validation with JWTCustomClaims)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTCustomClaims)
+        jwt.decode(compact, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
 
 
 def test_decode_invalid_signature(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     wrong_key = "wrongkey_but_long_enough"
-    compact = jwt.encode(claims, secret_key, "HS256").compact
+    compact = jwt.encode(claims, secret_key, Alg.HS256).compact
 
     with pytest.raises(SignatureVerificationFailedError):
-        jwt.decode(compact, wrong_key, "HS256")
+        jwt.decode(compact, wrong_key, Alg.HS256)
 
 
 def test_hmac_algorithms(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
-    hmac_algorithms: list[Algorithm] = ["HS256", "HS384", "HS512"]
+    hmac_algorithms = [Alg.HS256, Alg.HS384, Alg.HS512]
 
     for alg in hmac_algorithms:
         token = jwt.encode(claims, secret_key, alg).compact
@@ -206,19 +205,21 @@ def test_encode_decode_claims_validation_disabled(
     )  # zero validation (even for datetime)
     unvalidated_claims.sub = 1  # invalid type for sub  # type: ignore
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(unvalidated_claims, secret_key_random, "HS256")
+        jwt.encode(unvalidated_claims, secret_key_random, Alg.HS256)
     compact = jwt.encode(
         unvalidated_claims,
         secret_key_random,
-        "HS256",
+        Alg.HS256,
         claims_validation=Validation.DISABLE,
     ).compact
 
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(compact, secret_key_random, "HS256", claims_validation=JWTCustomClaims)
-    jwt.decode(compact, secret_key_random, "HS256")  # passes (no validation)
+        jwt.decode(
+            compact, secret_key_random, Alg.HS256, claims_validation=JWTCustomClaims
+        )
+    jwt.decode(compact, secret_key_random, Alg.HS256)  # passes (no validation)
     decoded = jwt.decode(
-        compact, secret_key_random, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key_random, Alg.HS256, claims_validation=Validation.DISABLE
     ).payload
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
@@ -236,30 +237,30 @@ def test_encode_decode_claims_dict_validation_disabled(
     unvalidated_claims_dict = claims_dict.copy()
     unvalidated_claims_dict["sub"] = 1  # invalid type for sub
     jwt.encode(
-        unvalidated_claims_dict, secret_key_random, "HS256"
+        unvalidated_claims_dict, secret_key_random, Alg.HS256
     )  # passes (no encode validation as dict)
     with pytest.raises(ClaimsValidationError):
         jwt.encode(
             unvalidated_claims_dict,
             secret_key_random,
-            "HS256",
+            Alg.HS256,
             claims_validation=JWTClaims,
         )
     # run encoding again with validation disabled, does not raise error
     compact = jwt.encode(
         unvalidated_claims_dict,
         secret_key_random,
-        "HS256",
+        Alg.HS256,
         claims_validation=Validation.DISABLE,
     ).compact
     jwt.decode(
-        compact, secret_key_random, "HS256"
+        compact, secret_key_random, Alg.HS256
     )  # passes (no decode validation as dict)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(compact, secret_key_random, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact, secret_key_random, Alg.HS256, claims_validation=JWTClaims)
     # run decoding again with validation disabled, does not raise error
     decoded = jwt.decode(
-        compact, secret_key_random, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key_random, Alg.HS256, claims_validation=Validation.DISABLE
     ).payload
     decoded_claims = JWTCustomClaims.model_construct(**decoded)
 
@@ -274,60 +275,60 @@ def test_encode_decode_claims_dict_validation_disabled(
 def test_custom_claims_validation(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     # test with a wrong object type for claims_validation
     with pytest.raises(TypeError):
-        jwt.encode(claims, secret_key, "HS256", claims_validation="not_a_model")  # type: ignore
+        jwt.encode(claims, secret_key, Alg.HS256, claims_validation="not_a_model")  # type: ignore
 
     claims.sub = None  # remove required field 'sub'  # type: ignore
 
     jwt.encode(
-        claims, secret_key, "HS256", claims_validation=JWTClaims
+        claims, secret_key, Alg.HS256, claims_validation=JWTClaims
     )  # passes because compliant with JWTClaims
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims, secret_key, "HS256", claims_validation=JWTCustomClaims)
+        jwt.encode(claims, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
     with pytest.raises(ClaimsValidationError):
         jwt.encode(
-            claims, secret_key, "HS256"
+            claims, secret_key, Alg.HS256
         )  # same as claims_validation=JWTCustomClaims (pydantic object is validated by default)
 
     claims.aud = 123  # invalid registered claim  # type: ignore
     with pytest.raises(ClaimsValidationError):
         jwt.encode(
-            claims, secret_key, "HS256", claims_validation=JWTClaims
+            claims, secret_key, Alg.HS256, claims_validation=JWTClaims
         )  # no more compliant with JWTClaims (aud should be str | list[str] | None)
 
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims, secret_key, "HS256", claims_validation=JWTCustomClaims)
+        jwt.encode(claims, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
     with pytest.raises(ClaimsValidationError):
         jwt.encode(
-            claims, secret_key, "HS256"
+            claims, secret_key, Alg.HS256
         )  # same as claims_validation=JWTCustomClaims
 
     compact = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact  # create token anyway
-    jwt.decode(compact, secret_key, "HS256")  # passes (no validation)
+    jwt.decode(compact, secret_key, Alg.HS256)  # passes (no validation)
     with pytest.raises(ClaimsValidationError):
         jwt.decode(
-            compact, secret_key, "HS256", claims_validation=JWTClaims
+            compact, secret_key, Alg.HS256, claims_validation=JWTClaims
         )  # fails JWTClaims validation (aud wrong type)
     with pytest.raises(ClaimsValidationError):
-        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTCustomClaims)
+        jwt.decode(compact, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
     decoded_claims = jwt.decode(
-        compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).payload
     with pytest.raises(pydantic.ValidationError):
         JWTCustomClaims(**decoded_claims)
 
     # test detached payload
-    jwt.encode(claims, secret_key, "HS256", claims_validation=Validation.DISABLE)
+    jwt.encode(claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE)
     compact_detached = jwt.detach_payload().compact  # switch to detached mode
     jwt.decode(
-        compact_detached, secret_key, "HS256", with_detached_payload=claims.to_dict()
+        compact_detached, secret_key, Alg.HS256, with_detached_payload=claims.to_dict()
     )  # passes (no validation)
     with pytest.raises(ClaimsValidationError):
         jwt.decode(
             compact_detached,
             secret_key,
-            "HS256",
+            Alg.HS256,
             claims_validation=JWTClaims,
             with_detached_payload=claims.to_dict(),
         )
@@ -335,7 +336,7 @@ def test_custom_claims_validation(jwt: JWT, claims: JWTCustomClaims, secret_key:
         jwt.decode(
             compact_detached,
             secret_key,
-            "HS256",
+            Alg.HS256,
             claims_validation=JWTCustomClaims,
             with_detached_payload=claims.to_dict(),
         )
@@ -344,7 +345,7 @@ def test_custom_claims_validation(jwt: JWT, claims: JWTCustomClaims, secret_key:
 def test_unsupported_b64_header(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     # 'b64' header parameter is not supported
     with pytest.raises(InvalidHeadersError):
-        jwt.encode(claims, secret_key, "HS256", headers={"alg": "HS256", "b64": False})
+        jwt.encode(claims, secret_key, Alg.HS256, headers={"alg": "HS256", "b64": False})
 
 
 def test_invalid_claims_future_dates(jwt: JWT, secret_key: str):
@@ -357,12 +358,12 @@ def test_invalid_claims_future_dates(jwt: JWT, secret_key: str):
         "exp": (now - timedelta(minutes=5)).timestamp(),
     }
 
-    jwt.encode(claims_dict, secret_key, "HS256")  # no validation
+    jwt.encode(claims_dict, secret_key, Alg.HS256)  # no validation
     jwt.encode(
-        claims_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims_dict, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )  # no validation
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims_dict, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.encode(claims_dict, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
     # nbf <= iat is invalid
     claims_dict = {
@@ -370,12 +371,12 @@ def test_invalid_claims_future_dates(jwt: JWT, secret_key: str):
         "iat": now.timestamp(),
         "nbf": (now - timedelta(minutes=5)).timestamp(),
     }
-    jwt.encode(claims_dict, secret_key, "HS256")  # no validation
+    jwt.encode(claims_dict, secret_key, Alg.HS256)  # no validation
     jwt.encode(
-        claims_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims_dict, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )  # no validation
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims_dict, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.encode(claims_dict, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
     # nbf >= exp is invalid
     claims_dict = {
@@ -384,17 +385,17 @@ def test_invalid_claims_future_dates(jwt: JWT, secret_key: str):
         "nbf": (now + timedelta(days=5)).timestamp(),
         "exp": (now + timedelta(minutes=5)).timestamp(),
     }
-    jwt.encode(claims_dict, secret_key, "HS256")  # no validation
+    jwt.encode(claims_dict, secret_key, Alg.HS256)  # no validation
     jwt.encode(
-        claims_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims_dict, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )  # no validation
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims_dict, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.encode(claims_dict, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
 
 def test_claims_type_error(jwt: JWT, secret_key: str):
     with pytest.raises(TypeError):
-        jwt.encode("not_a_dict_or_jwtclaims", secret_key, "HS256")  # type: ignore
+        jwt.encode("not_a_dict_or_jwtclaims", secret_key, Alg.HS256)  # type: ignore
 
 
 def test_unsafe_inspect(jwt: JWT, claims_fixed_dt, secret_key: str):
@@ -419,15 +420,15 @@ def test_unsafe_inspect(jwt: JWT, claims_fixed_dt, secret_key: str):
         b"7J8anGc2Ytg-vyaTVN0ln2IjouLupxgHXiIEwxTO-oE"
     )
 
-    compact = jwt.encode(claims_fixed_dt, secret_key, "HS256").compact
+    compact = jwt.encode(claims_fixed_dt, secret_key, Alg.HS256).compact
     assert compact.rsplit(b".", 1)[0] == compact.rsplit(b".", 1)[0]
 
-    decoded_claims = jwt.decode(compact, secret_key).payload
+    decoded_claims = jwt.decode(compact, secret_key, Alg.HS256).payload
     assert decoded_claims["sub"] == claims_fixed_dt.sub
 
     # check the JWT was tampered with
     with pytest.raises(SignatureVerificationFailedError):
-        jwt.decode(forged_compact, secret_key, "HS256")
+        jwt.decode(forged_compact, secret_key, Alg.HS256)
 
     # decode with no signature verification
     unsafe_token = inspect(forged_compact)
@@ -447,18 +448,20 @@ def test_unsafe_inspect(jwt: JWT, claims_fixed_dt, secret_key: str):
 
 
 def test_detached_payload(jwt: JWT, claims_fixed_dt, secret_key):
-    token = jwt.encode(claims_fixed_dt, secret_key, "HS256")
+    token = jwt.encode(claims_fixed_dt, secret_key, Alg.HS256)
     compact = token.compact
     token_detached = jwt.detach_payload()
     compact_detached = token_detached.compact
-    compact_detached2 = encode(claims_fixed_dt, secret_key, "HS256", detach_payload=True)
+    compact_detached2 = encode(
+        claims_fixed_dt, secret_key, Alg.HS256, detach_payload=True
+    )
     assert compact_detached == compact_detached2
 
     decoded_claims_detached = jwt.decode(
-        compact_detached, secret_key, "HS256", with_detached_payload=claims_fixed_dt
+        compact_detached, secret_key, Alg.HS256, with_detached_payload=claims_fixed_dt
     ).payload
     assert decoded_claims_detached == claims_fixed_dt.to_dict()
-    decoded_claims = jwt.decode(compact, secret_key, "HS256").payload
+    decoded_claims = jwt.decode(compact, secret_key, Alg.HS256).payload
     assert decoded_claims == decoded_claims_detached
 
 
@@ -470,17 +473,17 @@ def test_detached_payload_no_jws_instance(jwt: JWT):
 def test_expired_token(jwt: JWT, secret_key: str):
     claims = JWTClaims.model_construct(exp=datetime.now(UTC) - timedelta(days=1))
     compact = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     with pytest.raises(TokenExpiredError):
-        jwt.encode(claims, secret_key, "HS256")
-    jwt.decode(compact, secret_key, "HS256")  # passes (no validation)
+        jwt.encode(claims, secret_key, Alg.HS256)
+    jwt.decode(compact, secret_key, Alg.HS256)  # passes (no validation)
     decoded_claims = jwt.decode(
-        compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).payload
     assert decoded_claims["exp"] == claims.to_dict()["exp"]
     with pytest.raises(TokenExpiredError):
-        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
     # test with dict
     past_exp_dict = {
@@ -488,26 +491,26 @@ def test_expired_token(jwt: JWT, secret_key: str):
         "exp": (datetime.now(UTC) - timedelta(days=365)).timestamp(),
     }
     compact_dict = jwt.encode(
-        past_exp_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+        past_exp_dict, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     with pytest.raises(TokenExpiredError):
-        jwt.decode(compact_dict, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact_dict, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
 
 def test_not_yet_valid_token(jwt: JWT, secret_key: str):
     claims = JWTClaims.model_construct(nbf=datetime.now(UTC) + timedelta(days=1))
     compact = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     with pytest.raises(TokenNotYetValidError):
-        jwt.encode(claims, secret_key, "HS256")
-    jwt.decode(compact, secret_key, "HS256")  # passes (no validation)
+        jwt.encode(claims, secret_key, Alg.HS256)
+    jwt.decode(compact, secret_key, Alg.HS256)  # passes (no validation)
     decoded_claims = jwt.decode(
-        compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).payload
     assert decoded_claims["nbf"] == claims.to_dict()["nbf"]
     with pytest.raises(TokenNotYetValidError):
-        jwt.decode(compact, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
     # test with dict
     future_nbf_dict = {
@@ -515,10 +518,10 @@ def test_not_yet_valid_token(jwt: JWT, secret_key: str):
         "nbf": (datetime.now(UTC) + timedelta(days=365)).timestamp(),
     }
     compact_dict = jwt.encode(
-        future_nbf_dict, secret_key, "HS256", claims_validation=Validation.DISABLE
+        future_nbf_dict, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     with pytest.raises(TokenNotYetValidError):
-        jwt.decode(compact_dict, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact_dict, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
 
 def test_exp_nbf_validation_in_jwt_workflow(jwt: JWT, secret_key: str):
@@ -534,10 +537,10 @@ def test_exp_nbf_validation_in_jwt_workflow(jwt: JWT, secret_key: str):
         sub="user123", iat=past_iat, nbf=past_nbf, exp=past_exp
     )
     compact = jwt.encode(
-        valid_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        valid_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     decoded = jwt.decode(
-        compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     assert decoded.payload["iat"] == int(past_iat.timestamp())
     assert decoded.payload["nbf"] == int(past_nbf.timestamp())
@@ -548,61 +551,65 @@ def test_exp_nbf_validation_in_jwt_workflow(jwt: JWT, secret_key: str):
         sub="user123", exp=now - timedelta(hours=1)
     )
     compact_expired = jwt.encode(
-        past_exp_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        past_exp_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
 
     # Decoding with validation enabled should fail
     with pytest.raises(TokenExpiredError):
-        jwt.decode(compact_expired, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact_expired, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
     # Test encoding with future nbf WITHOUT iat (validation disabled), then decode with validation
     future_nbf_claims = JWTClaims.model_construct(
         sub="user123", nbf=now + timedelta(hours=1)
     )
     compact_not_yet = jwt.encode(
-        future_nbf_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        future_nbf_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
 
     # Decoding with validation enabled should fail
     with pytest.raises(TokenNotYetValidError):
-        jwt.decode(compact_not_yet, secret_key, "HS256", claims_validation=JWTClaims)
+        jwt.decode(compact_not_yet, secret_key, Alg.HS256, claims_validation=JWTClaims)
 
 
 def test_claims_model_data(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
     # encode + claims as pydantic
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=JWTCustomClaims)
+    token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
     assert isinstance(token.model.claims, JWTCustomClaims)
-    token = jwt.encode(claims, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
     assert isinstance(token.model.claims, JWTCustomClaims)
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=Validation.DISABLE)
+    token = jwt.encode(
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
+    )
     assert isinstance(token.model.claims, JWTBaseModel)
 
     # encode + claims as dict
     token = jwt.encode(
-        claims.to_dict(), secret_key, "HS256", claims_validation=JWTCustomClaims
+        claims.to_dict(), secret_key, Alg.HS256, claims_validation=JWTCustomClaims
     )
     assert isinstance(token.model.claims, JWTCustomClaims)
-    token = jwt.encode(claims.to_dict(), secret_key, "HS256")
+    token = jwt.encode(claims.to_dict(), secret_key, Alg.HS256)
     assert isinstance(token.model.claims, JWTBaseModel)
     token = jwt.encode(
-        claims.to_dict(), secret_key, "HS256", claims_validation=Validation.DISABLE
+        claims.to_dict(), secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     compact = token.compact
     assert isinstance(token.model.claims, JWTBaseModel)
 
     # decode
-    token = jwt.decode(compact, secret_key, "HS256", claims_validation=JWTCustomClaims)
+    token = jwt.decode(compact, secret_key, Alg.HS256, claims_validation=JWTCustomClaims)
     assert isinstance(token.model.claims, JWTCustomClaims)
-    token = jwt.decode(compact, secret_key, "HS256")
+    token = jwt.decode(compact, secret_key, Alg.HS256)
     assert isinstance(token.model.claims, JWTBaseModel)
-    token = jwt.decode(compact, secret_key, "HS256", claims_validation=Validation.DISABLE)
+    token = jwt.decode(
+        compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
+    )
     assert isinstance(token.model.claims, JWTBaseModel)
 
 
 def test_custom_headers_validation(jwt: JWT, secret_key: str):
     # test with a wrong object type for claims_validation
     with pytest.raises(TypeError):
-        jwt.encode({}, secret_key, "HS256", headers_validation="not_a_model")  # type: ignore
+        jwt.encode({}, secret_key, Alg.HS256, headers_validation="not_a_model")  # type: ignore
 
     class CustomHeader(JOSEHeader):
         custom_header: str
@@ -613,10 +620,10 @@ def test_custom_headers_validation(jwt: JWT, secret_key: str):
 
     # pydantic headers
     jwt.encode(
-        {}, secret_key, "HS256", headers=headers, headers_validation=JOSEHeader
+        {}, secret_key, Alg.HS256, headers=headers, headers_validation=JOSEHeader
     )  # passes
     with pytest.raises(HeadersValidationError):
-        jwt.encode({}, secret_key, "HS256", headers=headers)
+        jwt.encode({}, secret_key, Alg.HS256, headers=headers)
 
     # make headers no more compliant with JOSEHeader
     headers.typ = 123  # invalid type for typ # type: ignore
@@ -624,27 +631,27 @@ def test_custom_headers_validation(jwt: JWT, secret_key: str):
         jwt.encode(
             {},
             secret_key,
-            "HS256",
+            Alg.HS256,
             headers=headers,
             headers_validation=JOSEHeader,  # no longer compliant (typ should be str)
         )
     with pytest.raises(HeadersValidationError):
-        jwt.encode({}, secret_key, "HS256", headers=headers)
+        jwt.encode({}, secret_key, Alg.HS256, headers=headers)
 
     compact = jwt.encode(
-        {}, secret_key, "HS256", headers=headers, headers_validation=Validation.DISABLE
+        {}, secret_key, Alg.HS256, headers=headers, headers_validation=Validation.DISABLE
     ).compact
     decoded_claims = jwt.decode(
-        compact, secret_key, "HS256", headers_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, headers_validation=Validation.DISABLE
     ).payload
     with pytest.raises(HeadersValidationError):
         jwt.decode(
-            compact, secret_key, "HS256"
+            compact, secret_key, Alg.HS256
         )  # fails because validation defaults to JOSEHeader
     with pytest.raises(HeadersValidationError):
-        jwt.decode(compact, secret_key, "HS256", headers_validation=JOSEHeader)
+        jwt.decode(compact, secret_key, Alg.HS256, headers_validation=JOSEHeader)
     with pytest.raises(HeadersValidationError):
-        jwt.decode(compact, secret_key, "HS256", headers_validation=CustomHeader)
+        jwt.decode(compact, secret_key, Alg.HS256, headers_validation=CustomHeader)
     assert decoded_claims == {}
 
 
@@ -656,13 +663,13 @@ def test_headers_model_data(jwt: JWT, secret_key: str):
 
     # encode + headers as pydantic
     token = jwt.encode(
-        {}, secret_key, "HS256", headers=headers, headers_validation=CustomHeader
+        {}, secret_key, Alg.HS256, headers=headers, headers_validation=CustomHeader
     )
     assert isinstance(token.model.headers, CustomHeader)
-    token = jwt.encode({}, secret_key, "HS256", headers=headers)
+    token = jwt.encode({}, secret_key, Alg.HS256, headers=headers)
     assert isinstance(token.model.headers, JOSEHeader)
     token = jwt.encode(
-        {}, secret_key, "HS256", headers=headers, headers_validation=Validation.DISABLE
+        {}, secret_key, Alg.HS256, headers=headers, headers_validation=Validation.DISABLE
     )
     assert isinstance(token.model.headers, JWTBaseModel)
 
@@ -670,17 +677,17 @@ def test_headers_model_data(jwt: JWT, secret_key: str):
     token = jwt.encode(
         {},
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=headers.to_dict(),
         headers_validation=CustomHeader,
     )
     assert isinstance(token.model.headers, CustomHeader)
-    token = jwt.encode({}, secret_key, "HS256", headers=headers.to_dict())
+    token = jwt.encode({}, secret_key, Alg.HS256, headers=headers.to_dict())
     assert isinstance(token.model.headers, JOSEHeader)
     token = jwt.encode(
         {},
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=headers.to_dict(),
         headers_validation=Validation.DISABLE,
     )
@@ -688,12 +695,12 @@ def test_headers_model_data(jwt: JWT, secret_key: str):
     assert isinstance(token.model.headers, JWTBaseModel)
 
     # decode
-    token = jwt.decode(compact, secret_key, "HS256", headers_validation=CustomHeader)
+    token = jwt.decode(compact, secret_key, Alg.HS256, headers_validation=CustomHeader)
     assert isinstance(token.model.headers, CustomHeader)
-    token = jwt.decode(compact, secret_key, "HS256")
+    token = jwt.decode(compact, secret_key, Alg.HS256)
     assert isinstance(token.model.headers, JOSEHeader)
     token = jwt.decode(
-        compact, secret_key, "HS256", headers_validation=Validation.DISABLE
+        compact, secret_key, Alg.HS256, headers_validation=Validation.DISABLE
     )
     assert isinstance(token.model.headers, JWTBaseModel)
 
@@ -713,15 +720,15 @@ def test_custom_default_claims_validation_policy(
 
     # Valid claims dict should pass validation
     valid_claims = claims_dict.copy()
-    compact = jwt_strict.encode(valid_claims, secret_key, "HS256").compact
-    decoded_claims = jwt_strict.decode(compact, secret_key, "HS256").payload
+    compact = jwt_strict.encode(valid_claims, secret_key, Alg.HS256).compact
+    decoded_claims = jwt_strict.decode(compact, secret_key, Alg.HS256).payload
     assert decoded_claims["sub"] == valid_claims["sub"]
 
     # Invalid claims dict should fail validation (aud must be str or list[str])
     invalid_claims = claims_dict.copy()
     invalid_claims["aud"] = 123  # invalid type
     with pytest.raises(ClaimsValidationError):
-        jwt_strict.encode(invalid_claims, secret_key, "HS256")
+        jwt_strict.encode(invalid_claims, secret_key, Alg.HS256)
 
     # Test with invalid future dates (exp <= iat)
     now = datetime.now(UTC)
@@ -731,35 +738,35 @@ def test_custom_default_claims_validation_policy(
         "exp": (now - timedelta(minutes=5)).timestamp(),
     }
     with pytest.raises(ClaimsValidationError):
-        jwt_strict.encode(invalid_dates_claims, secret_key, "HS256")
+        jwt_strict.encode(invalid_dates_claims, secret_key, Alg.HS256)
 
     # Can still override validation on encode/decode
     compact_unvalidated = jwt_strict.encode(
-        invalid_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        invalid_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     # Decode with claims_validation=Validation.DISABLE should pass (no validation)
     jwt_strict.decode(
-        compact_unvalidated, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact_unvalidated, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     # Decode without specifying claims_validation should fail (uses custom default)
     with pytest.raises(ClaimsValidationError):
-        jwt_strict.decode(compact_unvalidated, secret_key, "HS256")
+        jwt_strict.decode(compact_unvalidated, secret_key, Alg.HS256)
 
     # Same for invalid_dates_claims
     compact_invalid_dates = jwt_strict.encode(
-        invalid_dates_claims, secret_key, "HS256", claims_validation=Validation.DISABLE
+        invalid_dates_claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     ).compact
     # Decode with claims_validation=Validation.DISABLE should pass (no validation)
     jwt_strict.decode(
-        compact_invalid_dates, secret_key, "HS256", claims_validation=Validation.DISABLE
+        compact_invalid_dates, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     # Decode without specifying claims_validation should fail (uses custom default)
     with pytest.raises(ClaimsValidationError):
-        jwt_strict.decode(compact_invalid_dates, secret_key, "HS256")
+        jwt_strict.decode(compact_invalid_dates, secret_key, Alg.HS256)
 
     # Compare with default JWT instance behavior (no validation for dict claims)
     jwt_default = JWT()
-    jwt_default.encode(invalid_claims, secret_key, "HS256")  # passes without validation
+    jwt_default.encode(invalid_claims, secret_key, Alg.HS256)  # passes without validation
 
 
 def test_custom_default_headers_validation_policy(secret_key: str):
@@ -778,35 +785,35 @@ def test_custom_default_headers_validation_policy(secret_key: str):
 
     # Valid custom headers should pass validation
     valid_headers = {"alg": "HS256", "custom_header": "custom_value"}
-    compact = jwt_custom.encode({}, secret_key, "HS256", headers=valid_headers).compact
-    decoded_claims = jwt_custom.decode(compact, secret_key, "HS256").payload
+    compact = jwt_custom.encode({}, secret_key, Alg.HS256, headers=valid_headers).compact
+    decoded_claims = jwt_custom.decode(compact, secret_key, Alg.HS256).payload
     assert decoded_claims == {}
 
     # Missing custom_header should fail validation
     invalid_headers = {"alg": "HS256"}  # missing custom_header
     with pytest.raises(HeadersValidationError):
-        jwt_custom.encode({}, secret_key, "HS256", headers=invalid_headers)
+        jwt_custom.encode({}, secret_key, Alg.HS256, headers=invalid_headers)
 
     # Can still override validation on encode/decode
     compact_unvalidated = jwt_custom.encode(
         {},
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=invalid_headers,
         headers_validation=Validation.DISABLE,
     ).compact
     # Decode with headers_validation=Validation.DISABLE should pass (no validation)
     jwt_custom.decode(
-        compact_unvalidated, secret_key, "HS256", headers_validation=Validation.DISABLE
+        compact_unvalidated, secret_key, Alg.HS256, headers_validation=Validation.DISABLE
     )
     # Decode without specifying headers_validation should fail (uses custom default)
     with pytest.raises(HeadersValidationError):
-        jwt_custom.decode(compact_unvalidated, secret_key, "HS256")
+        jwt_custom.decode(compact_unvalidated, secret_key, Alg.HS256)
 
     # Compare with default JWT instance behavior (validates with JOSEHeader, not CustomHeader)
     jwt_default = JWT()
     jwt_default.encode(
-        {}, secret_key, "HS256", headers=invalid_headers
+        {}, secret_key, Alg.HS256, headers=invalid_headers
     )  # passes with JOSEHeader validation
 
 
@@ -831,24 +838,26 @@ def test_custom_default_claims_validation_policy_no_force_pydantic(
     # (because force_validation_on_pydantic_model=False and default_validation_model=JWTClaims)
     with pytest.raises(ClaimsValidationError):
         jwt_custom.encode(
-            invalid_claims, secret_key, "HS256"
+            invalid_claims, secret_key, Alg.HS256
         )  # fails JWTClaims validation
 
     # Create valid claims according to JWTClaims but invalid for JWTCustomClaims
     partial_claims = JWTCustomClaims.model_construct(**claims_dict)
     partial_claims.user_id = None  # type: ignore
 
-    compact = jwt_custom.encode(partial_claims, secret_key, "HS256").compact
-    decoded_claims = jwt_custom.decode(compact, secret_key, "HS256").payload
+    compact = jwt_custom.encode(partial_claims, secret_key, Alg.HS256).compact
+    decoded_claims = jwt_custom.decode(compact, secret_key, Alg.HS256).payload
     assert "user_id" not in decoded_claims
 
     with pytest.raises(ClaimsValidationError):
-        jwt_custom.decode(compact, secret_key, "HS256", claims_validation=JWTCustomClaims)
+        jwt_custom.decode(
+            compact, secret_key, Alg.HS256, claims_validation=JWTCustomClaims
+        )
 
     # Compare with default JWT instance behavior (validates Pydantic models automatically)
     jwt_default = JWT()
     with pytest.raises(ClaimsValidationError):
-        jwt_default.encode(partial_claims, secret_key, "HS256")
+        jwt_default.encode(partial_claims, secret_key, Alg.HS256)
 
 
 def test_size_exceeded_error(secret_key: str):
@@ -859,96 +868,96 @@ def test_size_exceeded_error(secret_key: str):
     claims_enormous = {"data": "𒃲" * 3_100}  # will create a compact of ~> 50 KB
 
     # case passing
-    token_big = jwt_strict.encode(claims_big, secret_key, "HS256")
-    token_big2 = jwt_lenient.encode(claims_big, secret_key, "HS256")
+    token_big = jwt_strict.encode(claims_big, secret_key, Alg.HS256)
+    token_big2 = jwt_lenient.encode(claims_big, secret_key, Alg.HS256)
     assert token_big.signing_input == token_big2.signing_input
-    token_enormous = jwt_lenient.encode(claims_enormous, secret_key, "HS256")
-    jwt_lenient.decode(token_enormous.compact, secret_key, "HS256")
-    jwt_lenient.decode(token_big.compact, secret_key, "HS256")
-    jwt_strict.decode(token_big.compact, secret_key, "HS256")
+    token_enormous = jwt_lenient.encode(claims_enormous, secret_key, Alg.HS256)
+    jwt_lenient.decode(token_enormous.compact, secret_key, Alg.HS256)
+    jwt_lenient.decode(token_big.compact, secret_key, Alg.HS256)
+    jwt_strict.decode(token_big.compact, secret_key, Alg.HS256)
 
     # case failing
     with pytest.raises(SizeExceededError):
-        jwt_strict.encode(claims_enormous, secret_key, "HS256")
+        jwt_strict.encode(claims_enormous, secret_key, Alg.HS256)
     with pytest.raises(SizeExceededError):
-        jwt_strict.decode(token_enormous.compact, secret_key, "HS256")
+        jwt_strict.decode(token_enormous.compact, secret_key, Alg.HS256)
 
 
 def test_invalid_token_error_malformed_tokens(jwt: JWT, secret_key: str):
     """Test InvalidTokenError for various malformed token formats."""
     malformed_token_2_parts = b"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0"
     with pytest.raises(InvalidTokenError):
-        jwt.decode(malformed_token_2_parts, secret_key, "HS256")
+        jwt.decode(malformed_token_2_parts, secret_key, Alg.HS256)
 
     malformed_token_4_parts = (
         b"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.c2lnbmF0dXJl.ZXh0cmE"
     )
     with pytest.raises(InvalidTokenError):
-        jwt.decode(malformed_token_4_parts, secret_key, "HS256")
+        jwt.decode(malformed_token_4_parts, secret_key, Alg.HS256)
 
-    valid_token = jwt.encode({"sub": "test"}, secret_key, "HS256").compact
+    valid_token = jwt.encode({"sub": "test"}, secret_key, Alg.HS256).compact
     # Corrupt the signature part with invalid base64
     parts = valid_token.split(b".")
     invalid_signature_token = b".".join([parts[0], parts[1], b"!!!invalid-base64!!!"])
     with pytest.raises(InvalidTokenError):
-        jwt.decode(invalid_signature_token, secret_key, "HS256")
+        jwt.decode(invalid_signature_token, secret_key, Alg.HS256)
 
 
 def test_invalid_headers_error_base64_and_format(jwt: JWT, secret_key: str):
     """Test InvalidHeadersError for invalid base64 encoding and non-dict headers."""
-    valid_token = jwt.encode({"sub": "test"}, secret_key, "HS256").compact
+    valid_token = jwt.encode({"sub": "test"}, secret_key, Alg.HS256).compact
     parts = valid_token.split(b".")
 
     # Invalid base64 in headers
     invalid_header_token = b".".join([b"!!!invalid-base64!!!", parts[1], parts[2]])
     with pytest.raises(InvalidHeadersError):
-        jwt.decode(invalid_header_token, secret_key, "HS256")
+        jwt.decode(invalid_header_token, secret_key, Alg.HS256)
 
     # Non-dict headers
     array_header = urlsafe_b64encode(json.dumps(["HS256"]).encode())
     non_dict_header_token = b".".join([array_header, parts[1], parts[2]])
     with pytest.raises(InvalidHeadersError):
-        jwt.decode(non_dict_header_token, secret_key, "HS256")
+        jwt.decode(non_dict_header_token, secret_key, Alg.HS256)
 
     # Headers with invalid JSON (not a complete structure)
     invalid_json_headers = urlsafe_b64encode(b"{invalid json}")
     invalid_json_token = b".".join([invalid_json_headers, parts[1], parts[2]])
     with pytest.raises(InvalidHeadersError):
-        jwt.decode(invalid_json_token, secret_key, "HS256")
+        jwt.decode(invalid_json_token, secret_key, Alg.HS256)
 
 
 def test_invalid_payload_error_base64_and_format(jwt: JWT, secret_key: str):
     """Test InvalidPayloadError for invalid base64 encoding and non-dict payload."""
-    valid_token = jwt.encode({"sub": "test"}, secret_key, "HS256").compact
+    valid_token = jwt.encode({"sub": "test"}, secret_key, Alg.HS256).compact
     parts = valid_token.split(b".")
 
     # Invalid base64 in payload
     invalid_payload_token = b".".join([parts[0], b"!!!invalid-base64!!!", parts[2]])
     with pytest.raises(InvalidPayloadError):
-        jwt.decode(invalid_payload_token, secret_key, "HS256")
+        jwt.decode(invalid_payload_token, secret_key, Alg.HS256)
 
     # Non-dict payload
     array_payload = urlsafe_b64encode(json.dumps(["claim1", "claim2"]).encode())
     non_dict_payload_token = b".".join([parts[0], array_payload, parts[2]])
     with pytest.raises(InvalidPayloadError):
-        jwt.decode(non_dict_payload_token, secret_key, "HS256")
+        jwt.decode(non_dict_payload_token, secret_key, Alg.HS256)
 
     # Payload with invalid JSON (not a complete structure)
     invalid_json_payload = urlsafe_b64encode(b"{invalid json}")
     invalid_json_token = b".".join([parts[0], invalid_json_payload, parts[2]])
     with pytest.raises(InvalidPayloadError):
-        jwt.decode(invalid_json_token, secret_key, "HS256")
+        jwt.decode(invalid_json_token, secret_key, Alg.HS256)
 
 
 def test_detached_payload_conflict(jwt: JWT, secret_key: str):
     """Test InvalidTokenError when decoding a token with payload in detached mode."""
-    normal_token = jwt.encode({"sub": "test", "user_id": "123"}, secret_key, "HS256")
+    normal_token = jwt.encode({"sub": "test", "user_id": "123"}, secret_key, Alg.HS256)
 
     with pytest.raises(InvalidTokenError, match="Detached payload conflict"):
         jwt.decode(
             normal_token.compact,
             secret_key,
-            "HS256",
+            Alg.HS256,
             with_detached_payload={"sub": "test", "user_id": "123"},
         )
 
@@ -960,22 +969,22 @@ def test_timestamp_switching_modes(jwt, secret_key):
 
     # Encode with int mode
     claims.force_jwtdatetime_to_int()
-    token_int = jwt.encode(claims, secret_key, "HS256")
-    decoded_int = jwt.decode(token_int.compact, secret_key, "HS256")
+    token_int = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded_int = jwt.decode(token_int.compact, secret_key, Alg.HS256)
     assert isinstance(decoded_int.payload["iat"], int)
     assert decoded_int.payload["iat"] == int(now.timestamp())
 
     # Encode with float mode
     claims.force_jwtdatetime_to_float()
-    token_float = jwt.encode(claims, secret_key, "HS256")
-    decoded_float = jwt.decode(token_float.compact, secret_key, "HS256")
+    token_float = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded_float = jwt.decode(token_float.compact, secret_key, Alg.HS256)
     assert isinstance(decoded_float.payload["iat"], float)
     assert decoded_float.payload["iat"] == now.timestamp()
 
     # Invalid mode
     claims.internal__jwtdatetime_force_int = "invalid"  # type: ignore
     with pytest.raises(ValueError, match="Invalid timestamp config type"):
-        jwt.encode(claims, secret_key, "HS256")
+        jwt.encode(claims, secret_key, Alg.HS256)
 
 
 def test_mixed_datetime_serialization_types(jwt, secret_key):
@@ -1006,8 +1015,8 @@ def test_mixed_datetime_serialization_types(jwt, secret_key):
     )
     assert claims.internal__jwtdatetime_force_int is True
 
-    token = jwt.encode(claims, secret_key, "HS256")
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    token = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
 
     # exp should be int (because flag is True and it's JWTDatetime)
     assert isinstance(decoded.payload["exp"], int)
@@ -1026,8 +1035,8 @@ def test_mixed_datetime_serialization_types(jwt, secret_key):
     assert claims.internal__jwtdatetime_force_int is False
 
     # Encode and decode again
-    token2 = jwt.encode(claims, secret_key, "HS256")
-    decoded2 = jwt.decode(token2.compact, secret_key, "HS256")
+    token2 = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded2 = jwt.decode(token2.compact, secret_key, Alg.HS256)
 
     # exp should now be float (because flag is False and it's JWTDatetime)
     assert isinstance(decoded2.payload["exp"], float)
@@ -1046,8 +1055,8 @@ def test_mixed_datetime_serialization_types(jwt, secret_key):
     assert claims.internal__jwtdatetime_force_int is True
 
     # Encode and decode one more time
-    token3 = jwt.encode(claims, secret_key, "HS256")
-    decoded3 = jwt.decode(token3.compact, secret_key, "HS256")
+    token3 = jwt.encode(claims, secret_key, Alg.HS256)
+    decoded3 = jwt.decode(token3.compact, secret_key, Alg.HS256)
 
     # exp should be back to int
     assert isinstance(decoded3.payload["exp"], int)

--- a/tests/test_validation_cfg.py
+++ b/tests/test_validation_cfg.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from superjwt.definitions import (
+    Alg,
     JOSEHeader,
     JWTBaseModel,
     JWTClaims,
@@ -62,11 +63,11 @@ def test_jwt_custom_validation_config_with_dict_data():
 
     # Encode with custom validation config
     token = jwt.encode(
-        claims_dict, secret_key, "HS256", claims_validation=custom_validation
+        claims_dict, secret_key, Alg.HS256, claims_validation=custom_validation
     )
 
     # Verify timestamps are floats (from custom config)
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
     assert isinstance(decoded.payload["iat"], float)
     assert isinstance(decoded.payload["exp"], float)
 
@@ -92,11 +93,11 @@ def test_jwt_custom_validation_config_with_pydantic_model():
     )
 
     # Should validate against JWTClaims (not CustomClaims) because auto_validate is False
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=custom_validation)
+    token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=custom_validation)
     assert token.compact is not None
 
     # Verify decoding works
-    decoded = jwt.decode(token.compact, secret_key, "HS256")
+    decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
     assert decoded.payload["sub"] == "user123"
     assert decoded.payload["user_id"] == "uid123"
 
@@ -114,13 +115,13 @@ def test_jwt_validation_config_disabled():
 
     # Should succeed because validation is disabled
     token = jwt.encode(
-        invalid_claims, secret_key, "HS256", claims_validation=no_validation
+        invalid_claims, secret_key, Alg.HS256, claims_validation=no_validation
     )
     assert token.compact is not None
 
     # Decode also succeeds with validation disabled
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=no_validation
+        token.compact, secret_key, Alg.HS256, claims_validation=no_validation
     )
     assert decoded.payload["sub"] == 12345
 
@@ -139,7 +140,9 @@ def test_jwt_validation_config_with_custom_now():
     }
 
     # Encode with validation disabled to create the token
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=Validation.DISABLE)
+    token = jwt.encode(
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
+    )
 
     # Create validation config with spoofed 'now' set to past
     spoofed_validation = JWTValidationCfg(
@@ -149,7 +152,7 @@ def test_jwt_validation_config_with_custom_now():
 
     # Should succeed because we spoofed the time to be within validity
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=spoofed_validation
+        token.compact, secret_key, Alg.HS256, claims_validation=spoofed_validation
     )
     assert decoded.payload["sub"] == "user123"
 
@@ -157,7 +160,7 @@ def test_jwt_validation_config_with_custom_now():
     strict_validation = JWTValidationCfg(validation_model=JWTClaims)
     with pytest.raises(TokenExpiredError):
         jwt.decode(
-            token.compact, secret_key, "HS256", claims_validation=strict_validation
+            token.compact, secret_key, Alg.HS256, claims_validation=strict_validation
         )
 
 
@@ -175,7 +178,9 @@ def test_jwt_validation_config_with_custom_leeway():
     }
 
     # Encode with validation disabled
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=Validation.DISABLE)
+    token = jwt.encode(
+        claims, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
+    )
 
     # Default leeway (5 seconds) with JWTClaims validation should fail
     default_leeway_validation = JWTValidationCfg(
@@ -186,7 +191,7 @@ def test_jwt_validation_config_with_custom_leeway():
         jwt.decode(
             token.compact,
             secret_key,
-            "HS256",
+            Alg.HS256,
             claims_validation=default_leeway_validation,
         )
 
@@ -197,7 +202,7 @@ def test_jwt_validation_config_with_custom_leeway():
     )
 
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=large_leeway_validation
+        token.compact, secret_key, Alg.HS256, claims_validation=large_leeway_validation
     )
     assert decoded.payload["sub"] == "user123"
 
@@ -221,11 +226,11 @@ def test_jwt_validation_config_allow_future_iat():
         validation_model=JWTClaims,
         allow_future_iat=True,  # Allow future iat
     )
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=encode_validation)
+    token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=encode_validation)
 
     # Decoding with allow_future_iat=True should also succeed
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=encode_validation
+        token.compact, secret_key, Alg.HS256, claims_validation=encode_validation
     )
     assert decoded.payload["sub"] == "user123"
 
@@ -237,7 +242,7 @@ def test_jwt_validation_config_allow_future_iat():
 
     with pytest.raises(ClaimsValidationError):  # ValidationError for future iat
         jwt.decode(
-            token.compact, secret_key, "HS256", claims_validation=strict_validation
+            token.compact, secret_key, Alg.HS256, claims_validation=strict_validation
         )
 
 
@@ -262,12 +267,12 @@ def test_jwt_validation_config_combine_multiple_params():
     )
 
     token = jwt.encode(
-        claims_dict, secret_key, "HS256", claims_validation=encode_validation
+        claims_dict, secret_key, Alg.HS256, claims_validation=encode_validation
     )
 
     # Verify float timestamps
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        token.compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     assert isinstance(decoded.payload["iat"], float)
     assert isinstance(decoded.payload["exp"], float)
@@ -281,7 +286,7 @@ def test_jwt_validation_config_combine_multiple_params():
     )
 
     decoded2 = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=decode_validation
+        token.compact, secret_key, Alg.HS256, claims_validation=decode_validation
     )
     assert decoded2.payload["sub"] == "user123"
 
@@ -310,7 +315,7 @@ def test_jwt_custom_headers_validation_config_with_dict():
     token = jwt.encode(
         claims,
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=headers_dict,
         headers_validation=custom_headers_validation,
     )
@@ -319,7 +324,7 @@ def test_jwt_custom_headers_validation_config_with_dict():
     decoded = jwt.decode(
         token.compact,
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers_validation=custom_headers_validation,
     )
     assert decoded.headers["kid"] == "key-123"
@@ -344,14 +349,14 @@ def test_jwt_custom_headers_validation_config_with_pydantic():
     token = jwt.encode(
         claims,
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=headers,
         headers_validation=custom_validation,
     )
 
     # Decode and verify custom fields are preserved
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", headers_validation=Validation.DISABLE
+        token.compact, secret_key, Alg.HS256, headers_validation=Validation.DISABLE
     )
     assert decoded.headers["custom_field"] == "test-value"
     assert decoded.headers["version"] == 2
@@ -373,7 +378,7 @@ def test_jwt_headers_validation_config_disabled():
     token = jwt.encode(
         claims,
         secret_key,
-        "HS256",
+        Alg.HS256,
         headers=custom_headers,
         headers_validation=no_validation,
     )
@@ -381,7 +386,7 @@ def test_jwt_headers_validation_config_disabled():
 
     # Decode also succeeds with validation disabled
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", headers_validation=no_validation
+        token.compact, secret_key, Alg.HS256, headers_validation=no_validation
     )
     assert decoded.headers["custom"] == "value"
 
@@ -409,7 +414,7 @@ def test_jwt_encode_decode_different_validation_configs():
         exp=datetime.now(UTC) + timedelta(hours=1),
     )
 
-    token = jwt.encode(claims, secret_key, "HS256", claims_validation=encode_config)
+    token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=encode_config)
 
     # Decode with strict validation (int timestamps, smaller leeway)
     decode_config = JWTValidationCfg(
@@ -420,7 +425,7 @@ def test_jwt_encode_decode_different_validation_configs():
 
     # Should still decode successfully
     decoded = jwt.decode(
-        token.compact, secret_key, "HS256", claims_validation=decode_config
+        token.compact, secret_key, Alg.HS256, claims_validation=decode_config
     )
     assert decoded.payload["sub"] == "user123"
 
@@ -444,7 +449,7 @@ def test_jwt_validation_config_does_not_mutate_default():
     )
 
     claims = {"sub": "user123", "iat": datetime.now(UTC).timestamp()}
-    jwt.encode(claims, secret_key, "HS256", claims_validation=custom_config)
+    jwt.encode(claims, secret_key, Alg.HS256, claims_validation=custom_config)
 
     # Verify the default config wasn't mutated
     assert jwt.default_claims_validation.validation_model == JWTBaseModel
@@ -453,10 +458,10 @@ def test_jwt_validation_config_does_not_mutate_default():
 
     # Subsequent operations should use default config
     claims2 = JWTClaims(sub="user456", iat=datetime.now(UTC))
-    token2 = jwt.encode(claims2, secret_key, "HS256")  # Uses default
+    token2 = jwt.encode(claims2, secret_key, Alg.HS256)  # Uses default
 
     decoded = jwt.decode(
-        token2.compact, secret_key, "HS256", claims_validation=Validation.DISABLE
+        token2.compact, secret_key, Alg.HS256, claims_validation=Validation.DISABLE
     )
     # Should have int timestamps (from default config)
     assert isinstance(decoded.payload["iat"], int)
@@ -489,7 +494,7 @@ def test_jwt_validation_config_overrides_model_internal_values():
 
     # Encoding should fail because config's allow_future_iat=False overrides model's True
     with pytest.raises(ClaimsValidationError):
-        jwt.encode(claims, secret_key, "HS256", claims_validation=strict_validation)
+        jwt.encode(claims, secret_key, Alg.HS256, claims_validation=strict_validation)
 
     # Now test with permissive config that allows future iat
     permissive_validation = JWTValidationCfg(
@@ -501,6 +506,6 @@ def test_jwt_validation_config_overrides_model_internal_values():
 
     # This should succeed because config overrides model
     token = jwt.encode(
-        claims, secret_key, "HS256", claims_validation=permissive_validation
+        claims, secret_key, Alg.HS256, claims_validation=permissive_validation
     )
     assert token.compact is not None


### PR DESCRIPTION
- use `Alg`, an enum to declare the algorithm to use in encode/decode. `str` is still supported.

Example:

```python
from superjwt import Alg, JWTClaims, encode, decode

secret_key = "your-secret-key-of-len-32-bytes!"

claims = (
    JWTClaims(iss="my-app", sub="John Doe")
    .with_issued_at()
    .with_expiration(minutes=15)
)

compact: bytes = encode(claims, secret_key, Alg.HS256)

decoded: dict = decode(compact, secret_key, Alg.HS256, claims_validation=JWTClaims)
```