### PR TITLE
feat: configurable validation with JWTValidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - Time integrity validation update ([#55])
     - add leeway support for `'iat'`, `'exp'`, and `'nbf'` comparison against *now*
     - new check that `'iat'` is not in the future. Can be disabled via config.
-- `JWTValidationModelCfg` now support internal config params ([#56])
+- Validation can be configured via `JWTValidation` and supports internal params (leeway, timestamp format, ...etc) ([#62])
+- Select algorithm from `Alg` str Enum ([#57])
 
 ### :gear: Changes
 
@@ -31,7 +32,6 @@
 - `Validation` flag can be passed to choose between two modes: ([#39])
     - Validation.DEFAULT (default when nothing is specified)
     - Validation.DISABLE
-- Default validation behavior for claims and headers can now be customized with `JWTValidationModelCfg` ([#38])
 - `JWT` can receive a `max_token_bytes` parameter to control the allowed max token size ([#40])
 - `JWTClaims` now raises `TokenNotYetValidError` if `'nbf'` > `'iat'` (or present time) ([#41])
 
@@ -101,23 +101,23 @@
 :tada: superjwt repository initialization
 
 
-[#56]: /../../issues/56
-[#55]: /../../issues/55
-[#53]: /../../issues/53
-[#51]: /../../issues/51
-[#49]: /../../issues/49
-[#47]: /../../issues/47
-[#42]: /../../issues/42
-[#41]: /../../issues/41
-[#40]: /../../issues/40
-[#39]: /../../issues/39
-[#38]: /../../issues/38
-[#34]: /../../issues/34
-[#31]: /../../issues/31
-[#24]: /../../issues/24
-[#17]: /../../issues/17
-[#15]: /../../issues/15
-[#14]: /../../issues/14
-[#13]: /../../issues/13
-[#7]: /../../issues/7
-[#6]: /../../issues/6
+[#62]: https://github.com/ixunio/superjwt/issues/62
+[#57]: https://github.com/ixunio/superjwt/issues/57
+[#55]: https://github.com/ixunio/superjwt/issues/55
+[#53]: https://github.com/ixunio/superjwt/issues/53
+[#51]: https://github.com/ixunio/superjwt/issues/51
+[#49]: https://github.com/ixunio/superjwt/issues/49
+[#47]: https://github.com/ixunio/superjwt/issues/47
+[#42]: https://github.com/ixunio/superjwt/issues/42
+[#41]: https://github.com/ixunio/superjwt/issues/41
+[#40]: https://github.com/ixunio/superjwt/issues/40
+[#39]: https://github.com/ixunio/superjwt/issues/39
+[#34]: https://github.com/ixunio/superjwt/issues/34
+[#31]: https://github.com/ixunio/superjwt/issues/31
+[#24]: https://github.com/ixunio/superjwt/issues/24
+[#17]: https://github.com/ixunio/superjwt/issues/17
+[#15]: https://github.com/ixunio/superjwt/issues/15
+[#14]: https://github.com/ixunio/superjwt/issues/14
+[#13]: https://github.com/ixunio/superjwt/issues/13
+[#7]: https://github.com/ixunio/superjwt/issues/7
+[#6]: https://github.com/ixunio/superjwt/issues/6

--- a/superjwt/__init__.py
+++ b/superjwt/__init__.py
@@ -10,7 +10,7 @@ from superjwt.definitions import (
     JWTDatetime,
     JWTDatetimeFloat,
     JWTDatetimeInt,
-    JWTValidationCfg,
+    JWTValidation,
     Validation,
 )
 from superjwt.jwt import JWT
@@ -21,10 +21,14 @@ __all__ = [
     "JWT",
     "Alg",
     "JOSEHeader",
+    "JWSToken",
+    "JWTBaseModel",
     "JWTClaims",
     "JWTDatetime",
     "JWTDatetimeFloat",
     "JWTDatetimeInt",
+    "JWTValidation",
+    "Validation",
     "__version__",
     "decode",
     "encode",
@@ -40,11 +44,11 @@ def encode(
     headers: JOSEHeader | dict[str, Any] | None = None,
     detach_payload: bool = False,
     claims_validation: type[JWTBaseModel]
-    | JWTValidationCfg
+    | JWTValidation
     | Validation
     | None = Validation.DEFAULT,
     headers_validation: type[JOSEHeader]
-    | JWTValidationCfg
+    | JWTValidation
     | Validation
     | None = Validation.DEFAULT,
 ) -> bytes:
@@ -57,12 +61,12 @@ def encode(
         headers (JOSEHeader | dict[str, Any] | None, opt.): Custom JWS headers to include
             in the JWT. Will use default JWS headers if not provided.
         detach_payload (bool, opt.): whether to produce a JWT token with detached payload.
-        claims_validation (type[JWTBaseModel] | JWTValidationCfg | Validation | None, opt.):
-            Validation configuration for claims. Can be a pydantic model class, a JWTValidationCfg
+        claims_validation (type[JWTBaseModel] | JWTValidation | Validation | None, opt.):
+            Validation configuration for claims. Can be a pydantic model class, a JWTValidation
             instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
-            or None (disables validation).
-        headers_validation (type[JOSEHeader] | JWTValidationCfg | Validation | None, opt.):
-            Validation configuration for headers. Can be a pydantic model class, a JWTValidationCfg
+            or None (no validation).
+        headers_validation (type[JOSEHeader] | JWTValidation | Validation | None, opt.):
+            Validation configuration for headers. Can be a pydantic model class, a JWTValidation
             instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
             or None (no validation).
 
@@ -93,11 +97,11 @@ def decode(
     *,
     with_detached_payload: JWTClaims | dict[str, Any] | None = None,
     claims_validation: type[JWTBaseModel]
-    | JWTValidationCfg
+    | JWTValidation
     | Validation
     | None = Validation.DEFAULT,
     headers_validation: type[JOSEHeader]
-    | JWTValidationCfg
+    | JWTValidation
     | Validation
     | None = Validation.DEFAULT,
 ) -> dict[str, Any]:
@@ -109,12 +113,12 @@ def decode(
         algorithm (Algorithm): The algorithm to use for verifying the JWT.
         with_detached_payload (JWTClaims | dict[str, Any] | None, opt.):
             Detached payload to use for signature verification, if any.
-        claims_validation (type[JWTBaseModel] | JWTValidationCfg | Validation | None, opt.):
-            Validation configuration for claims. Can be a pydantic model class, a JWTValidationCfg
+        claims_validation (type[JWTBaseModel] | JWTValidation | Validation | None, opt.):
+            Validation configuration for claims. Can be a pydantic model class, a JWTValidation
             instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
-            or None (disables validation).
-        headers_validation (type[JOSEHeader] | JWTValidationCfg | Validation | None, opt.):
-            Validation configuration for headers. Can be a pydantic model class, a JWTValidationCfg
+            or None (no validation).
+        headers_validation (type[JOSEHeader] | JWTValidation | Validation | None, opt.):
+            Validation configuration for headers. Can be a pydantic model class, a JWTValidation
             instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
             or None (no validation).
 

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -471,90 +471,98 @@ def make_key(algorithm: Alg | Literal["none"] | str, key: str | bytes) -> BaseKe
     return key_type.import_key(key)
 
 
-class JWTValidationCfg(BaseModel):
+class JWTValidation(BaseModel):
+    """JWT data validation object."""
+
+    # ------------- General validation config -------------
+    """Enable or disable data validation."""
     enabled: bool = True
 
     """The pydantic model to use for data validation."""
-    validation_model: type[JWTBaseModel] = JWTBaseModel
+    validation_model: type[JWTBaseModel] | None = None
 
-    """Auto-validate pydantic model instances at encoding time."""
-    auto_validate_pydantic_model: bool = True
+    """Forward the data pydantic model to validation config (and its internal config)."""
+    forward_pydantic_model: bool = True
 
     """The default pydantic model to use for data storage when data is a dict."""
     data_model: type[JWTBaseModel] = Field(
         default_factory=lambda data: data["validation_model"]
     )
 
-    # ------------- JWTBaseModel internal config -------------
+    # ------------- JWTBaseModel specific internal config -------------
     """Spoofed 'now' datetime."""
     now: datetime | None = None
 
     """Timestamp format for JWTDatetime fields."""
-    jwtdatetime_force_int: bool = DEFAULT_JWTDATETIME_FORCE_INT
+    jwtdatetime_force_int: bool | None = None
 
-    # ------------- JWTClaims internal config -------------
+    # ------------- JWTClaims specific internal config -------------
     """Leeway for time-based validations, in seconds."""
-    leeway: float = DEFAULT_LEEWAY_SECONDS
+    leeway: float | None = None
 
     """Allow 'iat' claim to be in the future."""
-    allow_future_iat: bool = DEFAULT_ALLOW_FUTURE_IAT
+    allow_future_iat: bool | None = None
 
-    def _internal_params_matrix(self) -> list[tuple[str, type[JWTBaseModel]]]:
+    def _internal_params_matrix(self) -> list[tuple[str, type[JWTBaseModel], Any]]:
         return [
-            ("now", JWTBaseModel),
-            ("jwtdatetime_force_int", JWTBaseModel),
-            ("leeway", JWTClaims),
-            ("allow_future_iat", JWTClaims),
+            ("now", JWTBaseModel, None),
+            ("jwtdatetime_force_int", JWTBaseModel, DEFAULT_JWTDATETIME_FORCE_INT),
+            ("leeway", JWTClaims, DEFAULT_LEEWAY_SECONDS),
+            ("allow_future_iat", JWTClaims, DEFAULT_ALLOW_FUTURE_IAT),
         ]
 
     def _get_internal_cfg(self) -> dict[str, Any]:
         """Get internal config values as a dict for injection into validation."""
         internal_config = {}
-        for param, model_type in self._internal_params_matrix():
-            if issubclass(self.validation_model, model_type):
+        for param, model_type, _ in self._internal_params_matrix():
+            if self.validation_model is not None and issubclass(
+                self.validation_model, model_type
+            ):
                 internal_config[f"internal__{param}"] = getattr(self, param)
         return internal_config
 
-    def _inject_internal_cfg_into_model(self, model: JWTBaseModel) -> None:
-        """Inject config's internal values into a model instance."""
-        for param, model_type in self._internal_params_matrix():
-            if isinstance(model, model_type):
-                setattr(model, f"internal__{param}", getattr(self, param))
-
-    def _set_internal_cfg_from_model(self, model: JWTBaseModel) -> None:
-        """Extract internal values from a model instance into this config."""
-        for param, model_type in self._internal_params_matrix():
-            if isinstance(model, model_type):
-                setattr(self, param, getattr(model, f"internal__{param}"))
+    def apply_internal_cfg(self, model: JWTBaseModel | None = None) -> None:
+        """Set internal config values when unset, either from a compatible data model
+        or from default values."""
+        for param, model_type, default in self._internal_params_matrix():
+            if getattr(self, param) is None:  # only overwrite when unset
+                if model is not None and isinstance(model, model_type):
+                    setattr(self, param, getattr(model, f"internal__{param}"))
+                elif model is None:
+                    setattr(self, param, default)
 
     def run(self, data: JWTBaseModel | dict[str, Any]) -> dict[str, Any]:
         if self.enabled is False:
             return data.to_dict() if isinstance(data, JWTBaseModel) else data
 
+        if self.validation_model is None:
+            raise ValueError("Validation model is not set in JWTValidation")
+
         # case pydantic model
         if isinstance(data, JWTBaseModel):
             data_dict = data.to_dict()
-            temp = self.validation_model.model_construct(**data_dict)
-            self._inject_internal_cfg_into_model(temp)
-            temp.revalidate()
-            return data_dict
 
         # case dict
-        if isinstance(data, dict):
-            data_with_config = data | self._get_internal_cfg()
-            self.validation_model.model_validate(data_with_config)
-            return data
+        elif isinstance(data, dict):
+            data_dict = data.copy()
 
-        raise TypeError("Wrong type during data preparation and validation")
+        else:
+            raise TypeError("Wrong type during data preparation and validation")
+
+        ##### BEGIN VALIDATION #####
+        self.validation_model.model_validate(data_dict | self._get_internal_cfg())
+        ##### END VALIDATION #####
+
+        return data_dict
 
 
-JWTClaimsDefaultValidationCfg = JWTValidationCfg(
+JWTClaimsDefaultValidation = JWTValidation(
     validation_model=JWTBaseModel,
 )
-JWTClaimsStrictValidationCfg = JWTValidationCfg(
+JWTClaimsStrictValidation = JWTValidation(
     validation_model=JWTClaims,
 )
-JWTHeadersDefaultValidationCfg = JWTValidationCfg(
+JWTHeadersDefaultValidation = JWTValidation(
     validation_model=JOSEHeader,
 )
 
@@ -568,13 +576,15 @@ class Validation(Enum):
 
 def get_data_model(
     data: JWTBaseModel | dict[str, Any],
-    validation: type[JWTBaseModel] | JWTValidationCfg | Validation | None,
-    default_validation: JWTValidationCfg,
+    validation: type[JWTBaseModel] | JWTValidation | Validation | None,
+    default_validation: JWTValidation,
     fallback_model: type[JWTBaseModel],
 ) -> type[JWTBaseModel]:
     if validation is Validation.DEFAULT and isinstance(data, dict):
         return default_validation.data_model
-    elif isinstance(validation, JWTValidationCfg):
+    elif isinstance(validation, JWTValidation):
+        if validation.data_model is None:
+            return fallback_model
         return validation.data_model
     elif (
         isclass(validation)
@@ -588,39 +598,58 @@ def get_data_model(
 
 
 def get_validation_config(
-    validation: type[JWTBaseModel] | JWTValidationCfg | Validation | None,
-    default_validation: JWTValidationCfg,
-) -> JWTValidationCfg | type[JWTBaseModel]:
-    if validation is Validation.DISABLE or validation is None:
-        return JWTValidationCfg(enabled=False)
-    elif validation is Validation.DEFAULT:
-        return default_validation.model_copy(deep=True)  # make a copy, mutable object!!
-    elif isinstance(validation, JWTValidationCfg):
-        return validation.model_copy(deep=True)
-    elif isclass(validation) and issubclass(validation, JWTBaseModel):
-        return validation
-    raise TypeError("Wrong validation object type")
-
-
-def prepare_and_validate_data(
     data: JWTBaseModel | dict[str, Any],
-    validation: JWTValidationCfg | type[JWTBaseModel],
-) -> dict[str, Any]:
-    """Prepare data as dict and perform pydantic validation if required."""
+    validation: type[JWTBaseModel] | JWTValidation | Validation | None,
+    default_validation: JWTValidation,
+    fallback_data_model: type[JWTBaseModel],
+) -> JWTValidation:
+    data_model = get_data_model(data, validation, default_validation, fallback_data_model)
 
-    # case validation is a naive Pydantic model
-    # --> make the JWTValidationCfg instance
-    if isclass(validation) and issubclass(validation, JWTBaseModel):
-        validation = JWTValidationCfg(enabled=True, validation_model=validation)
-        # pass internal config when data is a pydantic model
+    # 1. case DISABLE
+    if (
+        validation is Validation.DISABLE
+        or validation is None
+        or (isinstance(validation, JWTValidation) and validation.enabled is False)
+    ):
+        return JWTValidation(enabled=False, data_model=data_model)
+
+    # 2. case DEFAULT (nothing was specified)
+    if validation is Validation.DEFAULT:
+        # make a copy, mutable object!!
+        validation_cfg = default_validation.model_copy(deep=True)
+        validation_cfg.data_model = data_model
         if isinstance(data, JWTBaseModel):
-            validation._set_internal_cfg_from_model(data)
+            # forward internal cfg from data model and overwrite when unset
+            validation_cfg.apply_internal_cfg(data)
+            # (maybe) set validation model to data model
+            if validation_cfg.forward_pydantic_model is True:
+                validation_cfg.validation_model = type(data)
+        else:
+            # set default values for unset internal config
+            validation_cfg.apply_internal_cfg()
+        return validation_cfg
 
-    # case validation is already a JWTValidationCfg instance
-    # --> (maybe) force validation on pydantic data model
-    elif isinstance(validation, JWTValidationCfg) and isinstance(data, JWTBaseModel):
-        if validation.auto_validate_pydantic_model is True:
-            validation.validation_model = type(data)
+    # 3. case CUSTOM
+    # 3.1 case JWTValidation instance
+    if isinstance(validation, JWTValidation):
+        # make a copy, mutable object!!
+        validation_cfg = validation.model_copy(deep=True)
 
-    assert isinstance(validation, JWTValidationCfg)
-    return validation.run(data)
+    # 3.2 case Pydantic model
+    elif isclass(validation) and issubclass(validation, JWTBaseModel):
+        validation_cfg = JWTValidation(validation_model=validation)
+
+    else:
+        raise TypeError("Wrong validation object type")
+
+    if isinstance(data, JWTBaseModel):
+        # forward internal cfg from data model and overwrite when unset
+        validation_cfg.apply_internal_cfg(data)
+    else:
+        # set default values for unset internal config
+        validation_cfg.apply_internal_cfg()
+
+    # add data model
+    validation_cfg.data_model = data_model
+
+    return validation_cfg

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -10,13 +10,11 @@ from superjwt.definitions import (
     JOSEHeader,
     JWSToken,
     JWSTokenLifeCycle,
-    JWTHeadersDefaultValidationCfg,
-    JWTValidationCfg,
+    JWTHeadersDefaultValidation,
+    JWTValidation,
     Validation,
-    get_data_model,
     get_jws_algorithm,
     get_validation_config,
-    prepare_and_validate_data,
 )
 from superjwt.exceptions import (
     AlgorithmMismatchError,
@@ -37,7 +35,7 @@ class JWS:
         self,
         algorithm: Alg | Literal["none"] | str,
         max_token_bytes: int = MAX_TOKEN_BYTES,
-        default_headers_validation: JWTValidationCfg = JWTHeadersDefaultValidationCfg,
+        default_headers_validation: JWTValidation = JWTHeadersDefaultValidation,
     ):
         self.token: JWSTokenLifeCycle = JWSTokenLifeCycle()
         self.algorithm: BaseJWSAlgorithm[BaseKey] = get_jws_algorithm(algorithm)
@@ -66,7 +64,7 @@ class JWS:
         key: BaseKey,
         *,
         headers_validation: type[JOSEHeader]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -76,20 +74,17 @@ class JWS:
         # prepare headers data and perform validation
         if headers is None:
             headers = JOSEHeader.make_default(self.algorithm.name)
+        headers_validation = self.get_headers_validation(headers, headers_validation)
+
         try:
-            headers_dict = prepare_and_validate_data(
-                data=headers,
-                validation=self.get_headers_validation_config(headers_validation),
-            )
+            headers_dict = headers_validation.run(headers)
         except ValidationError as e:
             raise HeadersValidationError(validation_errors=e.errors()) from e
 
         # set headers data
         self.token.verified.model.headers = cast(
             "JOSEHeader",
-            self.get_headers_data_model(headers, headers_validation).model_construct(
-                **headers_dict
-            ),
+            headers_validation.data_model.model_construct(**headers_dict),
         )
         self.token.verified.headers = headers_dict
         self.token.verified.encoded_headers = urlsafe_b64encode(
@@ -123,7 +118,7 @@ class JWS:
         *,
         with_detached_payload: dict[str, Any] | None = None,
         headers_validation: type[JOSEHeader]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -134,6 +129,9 @@ class JWS:
         self.decode_parts(compact, with_detached_payload)
 
         # validate headers and algorithm
+        headers_validation = self.get_headers_validation(
+            self.token.unsafe.headers, headers_validation
+        )
         self.validate_headers_and_algorithm(headers_validation)
 
         # verify signature
@@ -234,29 +232,18 @@ class JWS:
                 "Signature is not encoded as a valid Base64url"
             ) from e
 
-    def validate_headers_and_algorithm(
-        self,
-        validation_model: type[JOSEHeader]
-        | JWTValidationCfg
-        | Validation
-        | None = Validation.DEFAULT,
-    ) -> None:
-        headers_dict = self.token.unsafe.headers
-
+    def validate_headers_and_algorithm(self, headers_validation: JWTValidation) -> None:
         # validate headers
         try:
-            prepare_and_validate_data(
-                data=headers_dict,
-                validation=self.get_headers_validation_config(validation_model),
-            )
+            headers_validation.run(self.token.unsafe.headers)
         except ValidationError as e:
             raise HeadersValidationError(validation_errors=e.errors()) from e
 
         # set headers model data
         headers_dict = self.token.unsafe.headers
-        self.token.unsafe.model.headers = headers_validated = self.get_headers_data_model(
-            headers_dict, validation_model
-        ).model_construct(**headers_dict)
+        self.token.unsafe.model.headers = headers_validated = cast(
+            "JOSEHeader", headers_validation.data_model.model_construct(**headers_dict)
+        )
 
         # check algorithm match
         pass_through = self.algorithm.name == "none" and self._allow_none_algorithm
@@ -283,27 +270,14 @@ class JWS:
 
         return True
 
-    def get_headers_data_model(
+    def get_headers_validation(
         self,
         data: JOSEHeader | dict[str, Any],
-        validation: type[JOSEHeader]
-        | JWTValidationCfg
-        | Validation
-        | None = Validation.DEFAULT,
-    ) -> type[JOSEHeader]:
-        return cast(
-            "type[JOSEHeader]",
-            get_data_model(data, validation, self.default_headers_validation, JOSEHeader),
-        )
-
-    def get_headers_validation_config(
-        self,
-        validation: type[JOSEHeader]
-        | JWTValidationCfg
-        | Validation
-        | None = Validation.DEFAULT,
-    ) -> JWTValidationCfg | type[JOSEHeader]:
-        return cast(
-            "JWTValidationCfg | type[JOSEHeader]",
-            get_validation_config(validation, self.default_headers_validation),
+        validation: type[JOSEHeader] | JWTValidation | Validation | None,
+    ) -> JWTValidation:
+        return get_validation_config(
+            data,
+            validation,
+            self.default_headers_validation,
+            fallback_data_model=JOSEHeader,
         )

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, cast
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -9,14 +9,12 @@ from superjwt.definitions import (
     JOSEHeader,
     JWSToken,
     JWTBaseModel,
-    JWTClaimsDefaultValidationCfg,
-    JWTHeadersDefaultValidationCfg,
-    JWTValidationCfg,
+    JWTClaimsDefaultValidation,
+    JWTHeadersDefaultValidation,
+    JWTValidation,
     Validation,
-    get_data_model,
     get_validation_config,
     make_key,
-    prepare_and_validate_data,
 )
 from superjwt.exceptions import (
     ClaimsValidationError,
@@ -33,8 +31,8 @@ class JWT:
     def __init__(
         self,
         max_token_bytes: int = MAX_TOKEN_BYTES,
-        default_claims_validation: JWTValidationCfg = JWTClaimsDefaultValidationCfg,
-        default_headers_validation: JWTValidationCfg = JWTHeadersDefaultValidationCfg,
+        default_claims_validation: JWTValidation = JWTClaimsDefaultValidation,
+        default_headers_validation: JWTValidation = JWTHeadersDefaultValidation,
     ) -> None:
         self.jws: JWS
 
@@ -50,11 +48,11 @@ class JWT:
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
         headers_validation: type[JOSEHeader]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -67,12 +65,12 @@ class JWT:
                 Will default to 'HS256' (HMAC with SHA-256).
             headers (JOSEHeader | dict[str, Any] | None, opt.): Custom JWS headers to include
                 in the JWT. Will use default JWS headers if not provided.
-            claims_validation (type[JWTBaseModel] | JWTValidationCfg | Validation | None, opt.):
-                Validation configuration for claims. Can be a pydantic model class, a JWTValidationCfg
+            claims_validation (type[JWTBaseModel] | JWTValidation | Validation | None, opt.):
+                Validation configuration for claims. Can be a pydantic model class, a JWTValidation
                 instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
-                or None (disables validation).
-            headers_validation (type[JOSEHeader] | JWTValidationCfg | Validation | None, opt.):
-                Validation configuration for headers. Can be a pydantic model class, a JWTValidationCfg
+                or None (no validation).
+            headers_validation (type[JOSEHeader] | JWTValidation | Validation | None, opt.):
+                Validation configuration for headers. Can be a pydantic model class, a JWTValidation
                 instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
                 or None (no validation).
 
@@ -89,11 +87,10 @@ class JWT:
         # prepare claims data and perform validation
         if claims is None:
             claims = JWTBaseModel()
+        claims_validation = self.get_claims_validation(claims, claims_validation)
+
         try:
-            claims_dict = prepare_and_validate_data(
-                data=claims,
-                validation=self.get_claims_validation_config(claims_validation),
-            )
+            claims_dict = claims_validation.run(claims)
         except ValidationError as e:
             raise ClaimsValidationError(validation_errors=e.errors()) from e
 
@@ -110,11 +107,8 @@ class JWT:
         )
 
         # set claims model data
-        self.jws.token.verified.model.claims = cast(
-            "JWTBaseModel",
-            self.get_claims_data_model(claims, claims_validation).model_construct(
-                **claims_dict
-            ),
+        self.jws.token.verified.model.claims = (
+            claims_validation.data_model.model_construct(**claims_dict)
         )
 
         return self.jws.token.verified
@@ -140,11 +134,11 @@ class JWT:
         *,
         with_detached_payload: JWTBaseModel | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
         headers_validation: type[JOSEHeader]
-        | JWTValidationCfg
+        | JWTValidation
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -156,12 +150,12 @@ class JWT:
             algorithm (Algorithm): The algorithm to use for verifying the JWT.
             with_detached_payload (JWTBaseModel | dict[str, Any] | None, opt.):
                 Detached payload to use for signature verification, if any.
-            claims_validation (type[JWTBaseModel] | JWTValidationCfg | Validation | None, opt.):
-                Validation configuration for claims. Can be a pydantic model class, a JWTValidationCfg
+            claims_validation (type[JWTBaseModel] | JWTValidation | Validation | None, opt.):
+                Validation configuration for claims. Can be a pydantic model class, a JWTValidation
                 instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
-                or None (disables validation).
-            headers_validation (type[JOSEHeader] | JWTValidationCfg | Validation | None, opt.):
-                Validation configuration for headers. Can be a pydantic model class, a JWTValidationCfg
+                or None (no validation).
+            headers_validation (type[JOSEHeader] | JWTValidation | Validation | None, opt.):
+                Validation configuration for headers. Can be a pydantic model class, a JWTValidation
                 instance, Validation.DEFAULT (uses default validation), Validation.DISABLE (no validation),
                 or None (no validation).
 
@@ -182,13 +176,13 @@ class JWT:
         # CASE 1: detached payload mode
         if with_detached_payload is not None:
             self.jws.enable_detached_payload()
+            claims_validation = self.get_claims_validation(
+                with_detached_payload, claims_validation
+            )
 
             # prepare detached claims data and perform validation
             try:
-                claims_dict = prepare_and_validate_data(
-                    data=with_detached_payload,
-                    validation=self.get_claims_validation_config(claims_validation),
-                )
+                claims_dict = claims_validation.run(with_detached_payload)
             except ValidationError as e:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
 
@@ -208,22 +202,18 @@ class JWT:
                 key,
                 headers_validation=headers_validation,
             )
+            claims = self.jws.token.verified.payload
+            claims_validation = self.get_claims_validation(claims, claims_validation)
 
             # validate claims
             try:
-                claims_dict = prepare_and_validate_data(
-                    data=self.jws.token.verified.payload,
-                    validation=self.get_claims_validation_config(claims_validation),
-                )
+                claims_dict = claims_validation.run(claims)
             except ValidationError as e:
                 raise ClaimsValidationError(validation_errors=e.errors()) from e
 
         # set claims model data
-        self.jws.token.verified.model.claims = cast(
-            "JWTBaseModel",
-            self.get_claims_data_model(claims_dict, claims_validation).model_construct(
-                **claims_dict
-            ),
+        self.jws.token.verified.model.claims = (
+            claims_validation.data_model.model_construct(**claims_dict)
         )
 
         return self.jws.token.verified
@@ -257,23 +247,14 @@ class JWT:
 
         return self.jws.token.unsafe
 
-    def get_claims_data_model(
+    def get_claims_validation(
         self,
         data: JWTBaseModel | dict[str, Any],
-        validation: type[JWTBaseModel]
-        | JWTValidationCfg
-        | Validation
-        | None = Validation.DEFAULT,
-    ) -> type[JWTBaseModel]:
-        return get_data_model(
-            data, validation, self.default_claims_validation, JWTBaseModel
+        validation: type[JWTBaseModel] | JWTValidation | Validation | None,
+    ) -> JWTValidation:
+        return get_validation_config(
+            data,
+            validation,
+            self.default_claims_validation,
+            fallback_data_model=JWTBaseModel,
         )
-
-    def get_claims_validation_config(
-        self,
-        validation: type[JWTBaseModel]
-        | JWTValidationCfg
-        | Validation
-        | None = Validation.DEFAULT,
-    ) -> JWTValidationCfg | type[JWTBaseModel]:
-        return get_validation_config(validation, self.default_claims_validation)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -13,7 +13,7 @@ from superjwt.definitions import (
     JWTDatetime,
     JWTDatetimeFloat,
     JWTDatetimeInt,
-    JWTValidationCfg,
+    JWTValidation,
     Validation,
 )
 from superjwt.exceptions import (
@@ -711,9 +711,8 @@ def test_custom_default_claims_validation_policy(
     """Test JWT instance with custom default claims validation policy."""
 
     # Create JWT instance with strict claims validation by default (JWTClaims)
-    custom_validation_config = JWTValidationCfg(
+    custom_validation_config = JWTValidation(
         validation_model=JWTClaims,
-        auto_validate_pydantic_model=True,
         data_model=JWTClaims,
     )
     jwt_strict = JWT(default_claims_validation=custom_validation_config)
@@ -776,9 +775,8 @@ def test_custom_default_headers_validation_policy(secret_key: str):
         custom_header: str
 
     # Create JWT instance with custom headers validation by default
-    custom_validation_config = JWTValidationCfg(
+    custom_validation_config = JWTValidation(
         validation_model=CustomHeader,
-        auto_validate_pydantic_model=True,
         data_model=CustomHeader,
     )
     jwt_custom = JWT(default_headers_validation=custom_validation_config)
@@ -823,9 +821,9 @@ def test_custom_default_claims_validation_policy_no_force_pydantic(
     """Test JWT instance with custom default validation but force_validation_on_pydantic_model=False."""
 
     # Create JWT instance with custom validation but without forcing Pydantic validation
-    custom_validation_config = JWTValidationCfg(
+    custom_validation_config = JWTValidation(
         validation_model=JWTClaims,  # Validate against JWTClaims
-        auto_validate_pydantic_model=False,  # Don't force Pydantic model type
+        forward_pydantic_model=False,  # Don't force Pydantic model type
         data_model=JWTBaseModel,
     )
     jwt_custom = JWT(default_claims_validation=custom_validation_config)

--- a/tests/test_jwtvalidation.py
+++ b/tests/test_jwtvalidation.py
@@ -1,4 +1,4 @@
-"""Tests for custom JWTValidationCfg usage in JWT operations."""
+"""Tests for custom JWTValidation usage in JWT operations."""
 
 from datetime import datetime, timedelta
 
@@ -8,7 +8,7 @@ from superjwt.definitions import (
     JOSEHeader,
     JWTBaseModel,
     JWTClaims,
-    JWTValidationCfg,
+    JWTValidation,
     Validation,
 )
 from superjwt.exceptions import ClaimsValidationError, TokenExpiredError
@@ -42,13 +42,23 @@ class CustomHeader(JOSEHeader):
 # ============================================================================
 
 
+def test_no_validation_model_set(secret_key):
+    """Test that JWTValidation raises error if no validation model is set."""
+    cfg = JWTValidation()
+    jwt = JWT()
+    with pytest.raises(ValueError, match="Validation model is not set in JWTValidation"):
+        jwt.encode(
+            {}, secret_key, Alg.HS256, claims_validation=cfg
+        )  # Should work with default config
+
+
 def test_jwt_custom_validation_config_with_dict_data():
     """Test JWT encoding/decoding with custom validation config using dict data."""
     jwt = JWT()
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Create custom validation config
-    custom_validation = JWTValidationCfg(
+    custom_validation = JWTValidation(
         validation_model=JWTClaims,
         enabled=True,
         jwtdatetime_force_int=False,  # Use float timestamps
@@ -77,14 +87,11 @@ def test_jwt_custom_validation_config_with_pydantic_model():
     jwt = JWT()
     secret_key = "test-secret-key-32-bytes-long!!"
 
-    # Create custom validation config with auto_validate disabled
-    custom_validation = JWTValidationCfg(
+    custom_validation = JWTValidation(
         validation_model=JWTClaims,
-        auto_validate_pydantic_model=False,  # Don't auto-use the data's type
         enabled=True,
     )
 
-    # Create CustomClaims instance
     claims = CustomClaims.model_construct(
         sub="user123",
         user_id="uid123",
@@ -92,11 +99,10 @@ def test_jwt_custom_validation_config_with_pydantic_model():
         exp=datetime.now(UTC) + timedelta(hours=1),
     )
 
-    # Should validate against JWTClaims (not CustomClaims) because auto_validate is False
+    # Should validate against JWTClaims (not CustomClaims)
     token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=custom_validation)
     assert token.compact is not None
 
-    # Verify decoding works
     decoded = jwt.decode(token.compact, secret_key, Alg.HS256)
     assert decoded.payload["sub"] == "user123"
     assert decoded.payload["user_id"] == "uid123"
@@ -108,7 +114,7 @@ def test_jwt_validation_config_disabled():
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Create validation config with validation disabled
-    no_validation = JWTValidationCfg(enabled=False)
+    no_validation = JWTValidation(enabled=False)
 
     # Create invalid claims (invalid type for sub)
     invalid_claims = {"sub": 12345, "aud": ["audience1"]}  # sub should be string
@@ -145,7 +151,7 @@ def test_jwt_validation_config_with_custom_now():
     )
 
     # Create validation config with spoofed 'now' set to past
-    spoofed_validation = JWTValidationCfg(
+    spoofed_validation = JWTValidation(
         validation_model=JWTClaims,
         now=past_time + timedelta(minutes=30),  # Within the validity period
     )
@@ -157,7 +163,7 @@ def test_jwt_validation_config_with_custom_now():
     assert decoded.payload["sub"] == "user123"
 
     # Without spoofed time, should fail with strict validation (JWTClaims)
-    strict_validation = JWTValidationCfg(validation_model=JWTClaims)
+    strict_validation = JWTValidation(validation_model=JWTClaims)
     with pytest.raises(TokenExpiredError):
         jwt.decode(
             token.compact, secret_key, Alg.HS256, claims_validation=strict_validation
@@ -183,7 +189,7 @@ def test_jwt_validation_config_with_custom_leeway():
     )
 
     # Default leeway (5 seconds) with JWTClaims validation should fail
-    default_leeway_validation = JWTValidationCfg(
+    default_leeway_validation = JWTValidation(
         validation_model=JWTClaims,
         leeway=5.0,  # Default leeway - should NOT cover 8s expiration
     )
@@ -196,7 +202,7 @@ def test_jwt_validation_config_with_custom_leeway():
         )
 
     # Custom validation with larger leeway should succeed
-    large_leeway_validation = JWTValidationCfg(
+    large_leeway_validation = JWTValidation(
         validation_model=JWTClaims,
         leeway=10.0,  # 10 seconds leeway - should cover 8s expiration
     )
@@ -222,7 +228,7 @@ def test_jwt_validation_config_allow_future_iat():
     }
 
     # With allow_future_iat=True, encoding should succeed
-    encode_validation = JWTValidationCfg(
+    encode_validation = JWTValidation(
         validation_model=JWTClaims,
         allow_future_iat=True,  # Allow future iat
     )
@@ -235,7 +241,7 @@ def test_jwt_validation_config_allow_future_iat():
     assert decoded.payload["sub"] == "user123"
 
     # Default validation (allow_future_iat=False) should fail
-    strict_validation = JWTValidationCfg(
+    strict_validation = JWTValidation(
         validation_model=JWTClaims,
         allow_future_iat=False,  # Disallow future iat (default)
     )
@@ -260,7 +266,7 @@ def test_jwt_validation_config_combine_multiple_params():
     }
 
     # Encode with custom validation config (validation disabled to allow expired claims)
-    encode_validation = JWTValidationCfg(
+    encode_validation = JWTValidation(
         validation_model=JWTClaims,
         jwtdatetime_force_int=False,  # Use float timestamps
         enabled=False,  # Disable validation to allow creating expired token
@@ -278,7 +284,7 @@ def test_jwt_validation_config_combine_multiple_params():
     assert isinstance(decoded.payload["exp"], float)
 
     # Decode with custom validation (spoofed time + large leeway)
-    decode_validation = JWTValidationCfg(
+    decode_validation = JWTValidation(
         validation_model=JWTClaims,
         now=past_time + timedelta(minutes=15),  # Spoof to within validity
         leeway=20.0,  # Large leeway
@@ -302,7 +308,7 @@ def test_jwt_custom_headers_validation_config_with_dict():
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Create custom validation config for headers
-    custom_headers_validation = JWTValidationCfg(
+    custom_headers_validation = JWTValidation(
         validation_model=JOSEHeader,
         enabled=True,
     )
@@ -335,13 +341,10 @@ def test_jwt_custom_headers_validation_config_with_pydantic():
     jwt = JWT()
     secret_key = "test-secret-key-32-bytes-long!!"
 
-    # Create custom validation config with auto_validate disabled
-    custom_validation = JWTValidationCfg(
+    custom_validation = JWTValidation(
         validation_model=JOSEHeader,
-        auto_validate_pydantic_model=False,
     )
 
-    # Create CustomHeader instance
     headers = CustomHeader(alg="HS256", custom_field="test-value", version=2)
     claims = {"sub": "user123"}
 
@@ -368,7 +371,7 @@ def test_jwt_headers_validation_config_disabled():
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Create validation config with validation disabled
-    no_validation = JWTValidationCfg(enabled=False)
+    no_validation = JWTValidation(enabled=False)
 
     # Create headers with non-standard fields
     custom_headers = {"alg": "HS256", "typ": "JWT", "custom": "value"}
@@ -402,7 +405,7 @@ def test_jwt_encode_decode_different_validation_configs():
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Encode with relaxed validation (float timestamps)
-    encode_config = JWTValidationCfg(
+    encode_config = JWTValidation(
         validation_model=JWTClaims,
         jwtdatetime_force_int=False,
         leeway=5.0,
@@ -417,7 +420,7 @@ def test_jwt_encode_decode_different_validation_configs():
     token = jwt.encode(claims, secret_key, Alg.HS256, claims_validation=encode_config)
 
     # Decode with strict validation (int timestamps, smaller leeway)
-    decode_config = JWTValidationCfg(
+    decode_config = JWTValidation(
         validation_model=JWTClaims,
         jwtdatetime_force_int=True,
         leeway=2.0,
@@ -433,7 +436,7 @@ def test_jwt_encode_decode_different_validation_configs():
 def test_jwt_validation_config_does_not_mutate_default():
     """Test that using custom validation config doesn't mutate JWT default config."""
     # Create JWT with specific default validation
-    default_config = JWTValidationCfg(
+    default_config = JWTValidation(
         validation_model=JWTBaseModel,
         jwtdatetime_force_int=True,
         leeway=5.0,
@@ -442,7 +445,7 @@ def test_jwt_validation_config_does_not_mutate_default():
     secret_key = "test-secret-key-32-bytes-long!!"
 
     # Use different validation config for encoding
-    custom_config = JWTValidationCfg(
+    custom_config = JWTValidation(
         validation_model=JWTClaims,
         jwtdatetime_force_int=False,
         leeway=10.0,
@@ -482,14 +485,11 @@ def test_jwt_validation_config_overrides_model_internal_values():
 
     # Set model's internal values to allow future iat
     claims.allow_future_iat()
-    claims.set_leeway(15.0)  # Large leeway
 
     # Create validation config that should OVERRIDE model's settings
-    strict_validation = JWTValidationCfg(
+    strict_validation = JWTValidation(
         validation_model=JWTClaims,
         allow_future_iat=False,  # Override: disallow future iat
-        leeway=5.0,  # Override: smaller leeway
-        auto_validate_pydantic_model=True,
     )
 
     # Encoding should fail because config's allow_future_iat=False overrides model's True
@@ -497,11 +497,9 @@ def test_jwt_validation_config_overrides_model_internal_values():
         jwt.encode(claims, secret_key, Alg.HS256, claims_validation=strict_validation)
 
     # Now test with permissive config that allows future iat
-    permissive_validation = JWTValidationCfg(
+    permissive_validation = JWTValidation(
         validation_model=JWTClaims,
         allow_future_iat=True,  # Allow future iat
-        leeway=20.0,
-        auto_validate_pydantic_model=True,
     )
 
     # This should succeed because config overrides model
@@ -509,3 +507,181 @@ def test_jwt_validation_config_overrides_model_internal_values():
         claims, secret_key, Alg.HS256, claims_validation=permissive_validation
     )
     assert token.compact is not None
+
+
+def test_validation_config_inherits_none_values_from_model():
+    """Test that validation config inherits values from model only when config values are None."""
+    jwt = JWT()
+    secret_key = "test-secret-key-32-bytes-long!!"
+
+    # Create a JWTClaims instance with custom internal values
+    past_time = datetime.now(UTC) - timedelta(hours=1)
+    claims = JWTClaims.model_construct(
+        sub="user123",
+        iat=past_time,
+        exp=past_time + timedelta(hours=1),
+    )
+
+    # Set model's internal values
+    claims.set_leeway(20.0)
+    claims.allow_future_iat()
+    claims.force_jwtdatetime_to_float()
+    custom_now = past_time + timedelta(minutes=30)
+    claims.spoof_time(custom_now)
+
+    # Create validation config with ALL values as None (should inherit from model)
+    inherit_validation = JWTValidation(
+        validation_model=JWTClaims,
+        leeway=None,  # Should inherit 20.0 from model
+        allow_future_iat=None,  # Should inherit True from model
+        jwtdatetime_force_int=None,  # Should inherit False from model
+        now=None,  # Should inherit custom_now from model
+    )
+
+    # Encoding should succeed using model's inherited values
+    token = jwt.encode(
+        claims, secret_key, Alg.HS256, claims_validation=inherit_validation
+    )
+    assert token.compact is not None
+
+    # Verify that config inherited model's values by checking the config after apply_internal_cfg
+    validation_copy = inherit_validation.model_copy(deep=True)
+    validation_copy.apply_internal_cfg(claims)
+
+    assert validation_copy.leeway == 20.0
+    assert validation_copy.allow_future_iat is True
+    assert validation_copy.jwtdatetime_force_int is False
+    assert validation_copy.now == custom_now
+
+
+def test_validation_config_does_not_override_set_values():
+    """Test that validation config does NOT override its own set values with model values."""
+    # Create a JWTClaims instance with one set of internal values
+    past_time = datetime.now(UTC) - timedelta(hours=1)
+    claims = JWTClaims.model_construct(
+        sub="user123",
+        iat=past_time,
+        exp=past_time + timedelta(hours=1),
+    )
+
+    # Set model's internal values
+    claims.set_leeway(100.0)  # Very large leeway
+    claims.allow_future_iat()  # Allow future
+    claims.force_jwtdatetime_to_float()  # Float timestamps
+    model_now = past_time + timedelta(minutes=15)
+    claims.spoof_time(model_now)
+
+    # Create validation config with DIFFERENT set values (should NOT be overridden)
+    override_validation = JWTValidation(
+        validation_model=JWTClaims,
+        leeway=4.0,  # Should NOT be overridden by model's 100.0
+        allow_future_iat=False,  # Should NOT be overridden by model's True
+        jwtdatetime_force_int=True,  # Should NOT be overridden by model's False
+        now=past_time + timedelta(minutes=30),  # Should NOT be overridden by model's now
+    )
+
+    # Apply internal config to see what happens
+    validation_copy = override_validation.model_copy(deep=True)
+    validation_copy.apply_internal_cfg(claims)
+
+    # Verify that config's values were NOT overridden by model's values
+    assert validation_copy.leeway == 4.0  # NOT 100.0
+    assert validation_copy.allow_future_iat is False  # NOT True
+    assert validation_copy.jwtdatetime_force_int is True  # NOT False
+    assert validation_copy.now == past_time + timedelta(minutes=30)  # NOT model_now
+
+
+def test_validation_config_mixed_none_and_set_values():
+    """Test that validation config correctly handles mix of None and set values."""
+    # Create a JWTClaims instance with custom internal values
+    past_time = datetime.now(UTC) - timedelta(hours=1)
+    claims = JWTClaims.model_construct(
+        sub="user123",
+        iat=past_time,
+        exp=past_time + timedelta(hours=1),
+    )
+
+    # Set model's internal values
+    claims.set_leeway(50.0)
+    claims.allow_future_iat()
+    claims.force_jwtdatetime_to_float()
+    model_now = past_time + timedelta(minutes=20)
+    claims.spoof_time(model_now)
+
+    # Create validation config with MIXED values (some None, some set)
+    mixed_validation = JWTValidation(
+        validation_model=JWTClaims,
+        leeway=10.0,  # SET - should NOT be overridden
+        allow_future_iat=None,  # NONE - should inherit True from model
+        jwtdatetime_force_int=True,  # SET - should NOT be overridden
+        now=None,  # NONE - should inherit model_now from model
+    )
+
+    # Apply internal config
+    validation_copy = mixed_validation.model_copy(deep=True)
+    validation_copy.apply_internal_cfg(claims)
+
+    # Verify mixed behavior
+    assert validation_copy.leeway == 10.0  # Used config's value (NOT model's 50.0)
+    assert validation_copy.allow_future_iat is True  # Inherited from model
+    assert (
+        validation_copy.jwtdatetime_force_int is True
+    )  # Used config's value (NOT model's False)
+    assert validation_copy.now == model_now  # Inherited from model
+
+
+def test_validation_config_none_values_use_defaults_when_no_model():
+    """Test that validation config uses default values when values are None and no model is provided."""
+    from superjwt.definitions import (
+        DEFAULT_ALLOW_FUTURE_IAT,
+        DEFAULT_JWTDATETIME_FORCE_INT,
+        DEFAULT_LEEWAY_SECONDS,
+    )
+
+    # Create validation config with all None values
+    config = JWTValidation(
+        validation_model=JWTClaims,
+        leeway=None,
+        allow_future_iat=None,
+        jwtdatetime_force_int=None,
+        now=None,
+    )
+
+    # Apply internal config WITHOUT a model (should use defaults)
+    config.apply_internal_cfg(model=None)
+
+    # Verify default values were applied
+    assert config.leeway == DEFAULT_LEEWAY_SECONDS  # 5.0
+    assert config.allow_future_iat == DEFAULT_ALLOW_FUTURE_IAT  # False
+    assert config.jwtdatetime_force_int == DEFAULT_JWTDATETIME_FORCE_INT  # True
+    assert config.now is None  # Default for 'now' is None
+
+
+def test_validation_config_partial_inheritance_from_incompatible_model():
+    """Test that validation config only inherits values for compatible model types."""
+    # Create a JWTBaseModel instance (NOT JWTClaims)
+    base_claims = JWTBaseModel()
+    base_claims.force_jwtdatetime_to_float()
+    custom_now = datetime.now(UTC) - timedelta(hours=1)
+    base_claims.spoof_time(custom_now)
+
+    # Create validation config targeting JWTClaims with all None values
+    config = JWTValidation(
+        validation_model=JWTClaims,
+        leeway=None,
+        allow_future_iat=None,
+        jwtdatetime_force_int=None,
+        now=None,
+    )
+
+    # Apply internal config from JWTBaseModel
+    config.apply_internal_cfg(base_claims)
+
+    # JWTBaseModel parameters should be inherited
+    assert config.jwtdatetime_force_int is False  # Inherited from base_claims
+    assert config.now == custom_now  # Inherited from base_claims
+
+    # JWTClaims-specific parameters remain None (base_claims doesn't have them
+    # and model is not None, so defaults are not applied)
+    assert config.leeway is None  # Stays None (not default, not from model)
+    assert config.allow_future_iat is None  # Stays None (not default, not from model)


### PR DESCRIPTION
- Configure validation by passing a `JWTValidation` instance instead of a mere Pydantic model
- Can be used to overwrite internal config (`leeway`, `allow_future_iat`, `jwtdatetime_force_int`, `now`)

### ENCODING EXAMPLE

```python
class MyJWTClaims(JWTClaims):
    user_id: str

# Create a MyJWTClaims instance with future iat
future_time = datetime.now(UTC) + timedelta(minutes=10)
claims = MyJWTClaims.model_construct(
    user_id="user123",
    iat=future_time,
    exp=future_time + timedelta(hours=1),
)

# Set model's internal values to allow future iat
claims.allow_future_iat()

# Create validation config that should OVERRIDE model's settings during encoding
strict_validation = JWTValidation(
    validation_model=MyJWTClaims,
    allow_future_iat=False,  # Override: disallow future iat
)

try:
    encode(claims, secret_key, Alg.HS256, claims_validation=validation)  # fails, iat in the future
except ClaimsValidationError as e:
    print(e)
    #> 'iat' claim must not be in the future

# Switch back to allow iat in the future
permissive_validation = JWTValidation(
    validation_model=MyJWTClaims,
    allow_future_iat=True,  # Allow future iat
)

compact = encode(
    claims, secret_key, Alg.HS256, claims_validation=permissive_validation
)
```

### DECODING EXAMPLE

```python
class MyJWTClaims(JWTClaims):
    user_id: str

high_leeway_validation = JWTValidation(
    validation_model=MyJWTClaims,
    leeway=20.0  # instead of 5.0 by default!
)

# decoding on a system with huge clock skew
decoded = decode(compact, secret_key, Alg.HS256, claims_validation=high_leeway_validation)
```