### PR TITLE
refactor: rename security exc & warning (breaking)

### DIFF
--- a/superjwt/exceptions.py
+++ b/superjwt/exceptions.py
@@ -5,6 +5,10 @@ class SecurityWarning(UserWarning):
     """Base class for warnings of security issues."""
 
 
+class KeyLengthSecurityWarning(SecurityWarning):
+    """Base class for warnings of security issues."""
+
+
 class SuperJWTError(Exception):
     """Base class for all SuperJWT related errors."""
 
@@ -26,7 +30,7 @@ class InvalidTokenError(SuperJWTError):
         super().__init__(self.error)
 
 
-class SignatureVerificationFailedError(InvalidTokenError):
+class SignatureVerificationError(InvalidTokenError):
     """Raised when signature verification fails despite token
     being valid in its format. The token may have been tampered with."""
 

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -22,7 +22,7 @@ from superjwt.exceptions import (
     InvalidHeadersError,
     InvalidPayloadError,
     InvalidTokenError,
-    SignatureVerificationFailedError,
+    SignatureVerificationError,
     SizeExceededError,
     SuperJWTError,
 )
@@ -262,7 +262,7 @@ class JWS:
             self.token.unsafe.signature,
             key,
         ):
-            raise SignatureVerificationFailedError()
+            raise SignatureVerificationError()
 
         if not isinstance(self.algorithm, NoneAlgorithm):
             self.token.verified = self.token.unsafe.model_copy()

--- a/superjwt/keys.py
+++ b/superjwt/keys.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 from typing_extensions import Self
 
-from superjwt.exceptions import InvalidKeyError, SecurityWarning
+from superjwt.exceptions import InvalidKeyError, KeyLengthSecurityWarning
 from superjwt.utils import as_bytes, is_pem_format, is_ssh_key
 
 
@@ -52,5 +52,7 @@ class OctKey(SymmetricKey):
             )
         if len(private_key) < 14:
             # https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final
-            warnings.warn("Key size should be >= 112 bits", SecurityWarning, stacklevel=3)
+            warnings.warn(
+                "Key size should be >= 112 bits", KeyLengthSecurityWarning, stacklevel=3
+            )
         self.private_key = private_key

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -22,7 +22,7 @@ from superjwt.exceptions import (
     InvalidHeadersError,
     InvalidPayloadError,
     InvalidTokenError,
-    SignatureVerificationFailedError,
+    SignatureVerificationError,
     SizeExceededError,
     SuperJWTError,
     TokenExpiredError,
@@ -182,7 +182,7 @@ def test_decode_invalid_signature(jwt: JWT, claims: JWTCustomClaims, secret_key:
     wrong_key = "wrongkey_but_long_enough"
     compact = jwt.encode(claims, secret_key, Alg.HS256).compact
 
-    with pytest.raises(SignatureVerificationFailedError):
+    with pytest.raises(SignatureVerificationError):
         jwt.decode(compact, wrong_key, Alg.HS256)
 
 
@@ -427,7 +427,7 @@ def test_unsafe_inspect(jwt: JWT, claims_fixed_dt, secret_key: str):
     assert decoded_claims["sub"] == claims_fixed_dt.sub
 
     # check the JWT was tampered with
-    with pytest.raises(SignatureVerificationFailedError):
+    with pytest.raises(SignatureVerificationError):
         jwt.decode(forged_compact, secret_key, Alg.HS256)
 
     # decode with no signature verification


### PR DESCRIPTION
naming alignment (breaking)
- use `KeyLengthSecurityWarning` when key size too low
- use `SignatureVerificationError` for non verifiable JWT