### PR TITLE
✨ Generate keys

### DIFF
--- a/superjwt/algorithms.py
+++ b/superjwt/algorithms.py
@@ -1,7 +1,7 @@
 import hashlib
 import hmac
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar, cast
 
 from superjwt.exceptions import SuperJWTError
 from superjwt.keys import BaseKey, ECKey, NoneKey, OctKey, OKPKey, RSAKey
@@ -59,6 +59,23 @@ class HMACWithSHAAlgorithm(BaseJWSAlgorithm[OctKey]):
     def __init__(self, hash_algorithm: Any):
         self.hash_algorithm = hash_algorithm
 
+    def generate_key(self, key_size: int | None = None) -> OctKey:
+        """Generate a random symmetric key for HMAC.
+
+        Args:
+            key_size: The size of the key in bytes. If None, uses the hash output size.
+                      For HS256: defaults to 32 bytes (256 bits)
+                      For HS384: defaults to 48 bytes (384 bits)
+                      For HS512: defaults to 64 bytes (512 bits)
+
+        Returns:
+            A new OctKey instance with a randomly generated key.
+        """
+        final_key_size = (
+            key_size if key_size is not None else self.hash_algorithm().digest_size
+        )
+        return self.key_type.generate(final_key_size)
+
     def check_key(self, key: OctKey) -> None:
         if not isinstance(key, OctKey):
             raise SuperJWTError("Key must be an OctKey for HMAC algorithms")
@@ -79,6 +96,16 @@ class RSAAlgorithm(BaseJWSAlgorithm[RSAKey]):
         check_cryptography_available()
         self.hash_algorithm = hash_algorithm
         self.padding = padding
+
+    def generate_key(self, key_size: Literal[2048, 3072, 4096] = 2048) -> RSAKey:
+        """Generate a new RSA key pair.
+
+        Args:
+            key_size: The size of the key in bits. Default is 2048.
+                      Recommended values: 2048, 3072, 4096.
+        """
+
+        return self.key_type.generate(key_size)
 
     def check_key(self, key: RSAKey) -> None:
         if not isinstance(key, RSAKey):
@@ -130,6 +157,10 @@ class ECDSAAlgorithm(BaseJWSAlgorithm[ECKey]):
         self.hash_algorithm = hash_algorithm
         self.curve = curve
         self.curve_name = curve.name
+
+    def generate_key(self) -> ECKey:
+        """Generate a new EC key pair for this algorithm's curve."""
+        return self.key_type.generate(self.curve())
 
     def check_key(self, key: ECKey) -> None:
         if not isinstance(key, ECKey):
@@ -189,6 +220,10 @@ class EdDSAAlgorithm(BaseJWSAlgorithm[OKPKey]):
         check_cryptography_available()
         self.curve_type_private = curve_type_private
         self.curve_type_public = curve_type_public
+
+    def generate_key(self) -> OKPKey:
+        """Generate a new OKP key pair for this algorithm's curve."""
+        return self.key_type.generate(cast("Literal['Ed25519', 'Ed448']", self.name))
 
     def check_key(self, key: OKPKey) -> None:
         if not isinstance(key, OKPKey):

--- a/superjwt/definitions.py
+++ b/superjwt/definitions.py
@@ -61,7 +61,6 @@ MAX_TOKEN_BYTES: int = 16 * 1024  # 16 KB
 class Alg(str, Enum):
     """JWS/JWT Algorithm names with associated implementation instances."""
 
-    none = "none"
     HS256 = "HS256"
     HS384 = "HS384"
     HS512 = "HS512"
@@ -98,9 +97,11 @@ class Alg(str, Enum):
         return getattr(Alg, name).get_instance()
 
     @classmethod
-    def get_algorithm(cls, algorithm: Self | Literal["none"] | str) -> BaseJWSAlgorithm:
+    def get_algorithm(cls, algorithm: Self | BaseJWSAlgorithm | str) -> BaseJWSAlgorithm:
         if isinstance(algorithm, cls):
             return algorithm.get_instance()
+        elif isinstance(algorithm, BaseJWSAlgorithm):
+            return algorithm
         else:
             return cls.get_instance_by_name(algorithm)
 

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 from pydantic import ValidationError
 
@@ -33,7 +33,7 @@ from superjwt.utils import as_bytes, urlsafe_b64decode, urlsafe_b64encode
 class JWS:
     def __init__(
         self,
-        algorithm: Alg | Literal["none"] | str,
+        algorithm: Alg | BaseJWSAlgorithm | str,
         max_token_bytes: int = MAX_TOKEN_BYTES,
         default_headers_validation: JWTValidation = JWTHeadersDefaultValidation,
     ):

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -233,8 +233,9 @@ class JWT:
         Returns:
             JWSToken: a JWSToken instance representing the unsafe non-verified decoded JWT token.
         """
+        from superjwt.algorithms import NoneAlgorithm
 
-        self.jws = JWS("none", max_token_bytes=self.max_token_bytes)
+        self.jws = JWS(NoneAlgorithm(), max_token_bytes=self.max_token_bytes)
 
         if has_detached_payload:
             self.jws.enable_detached_payload()

--- a/superjwt/keys.py
+++ b/superjwt/keys.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import secrets
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar, cast
 
-from superjwt.exceptions import InvalidKeyError, KeyLengthSecurityWarning
+from superjwt.exceptions import InvalidKeyError, KeyLengthSecurityWarning, SuperJWTError
 from superjwt.utils import (
     as_bytes,
     check_cryptography_available,
@@ -19,7 +20,7 @@ if check_cryptography_available(raise_error=False):  # pragma: no cover
     from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing_extensions import Self
 
 
@@ -116,7 +117,7 @@ class SymmetricKey(BaseKey):
 
     def _prepare_key(self, secret_key: bytes, _) -> None:
         if _ is not None:
-            raise InvalidKeyError("Symmetric key should not have a public key component")
+            raise SuperJWTError("Symmetric key should not have a public key component")
         if is_pem_format(secret_key) or is_ssh_key(secret_key):
             raise InvalidKeyError(
                 "The specified key is an asymmetric key or x509 certificate and"
@@ -137,6 +138,26 @@ class OctKey(SymmetricKey):
     name = "oct"
     description = "Octet sequence key for HMAC algorithms"
     algorithms = ("HS256", "HS384", "HS512")
+
+    @classmethod
+    def generate(cls, key_size: int = 32, *, human_readable: bool = True) -> Self:
+        """Generate a random symmetric key.
+
+        Args:
+            key_size: The size of the key in bytes. Default is 32 bytes (256 bits).
+                      Recommended values:
+                      - 32 bytes (256 bits) for HS256
+                      - 48 bytes (384 bits) for HS384
+                      - 64 bytes (512 bits) for HS512
+            human_readable: If True, returns key as hex string (default).
+                           If False, returns raw bytes.
+
+        Returns:
+            A new OctKey instance with a randomly generated key.
+        """
+        random_key_bytes = secrets.token_bytes(key_size)
+        random_key = random_key_bytes.hex() if human_readable else random_key_bytes
+        return cls.import_key(random_key, None)
 
 
 if TYPE_CHECKING:
@@ -277,9 +298,6 @@ class AsymmetricKey(BaseKey, Generic[PrivateKeyType, PublicKeyType]):
 
         Returns:
             Tuple of (public_key_obj, public_key_pem)
-
-        Raises:
-            InvalidKeyError: If no private key is loaded
         """
         assert self._private_key_obj is not None
         derived_public_key_obj = cast("PublicKeyType", self._private_key_obj.public_key())
@@ -333,24 +351,70 @@ class AsymmetricKey(BaseKey, Generic[PrivateKeyType, PublicKeyType]):
     def _get_private_key(self) -> PrivateKeyType:
         """Get the cryptography private key object for signing."""
         if self._private_key_obj is None:
-            raise InvalidKeyError(
-                "This key does not have a private component for signing"
-            )
+            raise SuperJWTError("This key does not have a private component for signing")
         return self._private_key_obj
 
     def _get_public_key(self) -> PublicKeyType:
         """Get the cryptography public key object for verification."""
         if self._public_key_obj is None:
-            raise InvalidKeyError(
+            raise SuperJWTError(
                 "This key does not have a public component for verification"
             )
         return self._public_key_obj
+
+    def export_private_key_pem(self) -> bytes:
+        """Export the private key as PEM-encoded PKCS8 format.
+
+        Returns:
+            bytes: The private key in PEM format (PKCS8)
+        """
+        private_key_obj = self._get_private_key()
+        return private_key_obj.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def export_public_key_pem(self) -> bytes:
+        """Export the public key as PEM-encoded SubjectPublicKeyInfo format.
+
+        If only a private key is available, derives and exports the public key from it.
+
+        Returns:
+            bytes: The public key in PEM format (SubjectPublicKeyInfo)
+        """
+        public_key_obj = self._get_public_key()
+        return public_key_obj.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
 
 
 class RSAKey(AsymmetricKey["rsa.RSAPrivateKey", "rsa.RSAPublicKey"]):
     name = "RSA"
     description = "RSA key for RSASSA-PKCS1-v1_5 and RSASSA-PSS algorithms"
     algorithms = ("RS256", "RS384", "RS512", "PS256", "PS384", "PS512")
+
+    @classmethod
+    def generate(cls, key_size: Literal[2048, 3072, 4096]) -> Self:
+        """Generate a new RSA key pair.
+
+        Args:
+            key_size: The size of the key in bits.
+                      Recommended values: 2048, 3072, 4096.
+        """
+        check_cryptography_available()
+        private_key_obj = rsa.generate_private_key(
+            public_exponent=65537, key_size=key_size, backend=default_backend()
+        )
+
+        private_key_pem = private_key_obj.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        return cls.import_key(private_key=private_key_pem)
 
     @property
     def private_key_types(self) -> tuple[type, ...]:
@@ -386,6 +450,78 @@ class ECKey(AsymmetricKey["ec.EllipticCurvePrivateKey", "ec.EllipticCurvePublicK
         "secp256k1, secp384r1 (P-384), and secp521r1 (P-521)"
     )
     algorithms = ("ES256", "ES256K", "ES384", "ES512")
+
+    @classmethod
+    def generate(
+        cls,
+        curve: ec.EllipticCurve
+        | Literal[
+            # for ES256 algorithm
+            "ES256",
+            "secp256r1",
+            "P-256",
+            # for ES256K algorithm
+            "ES256K",
+            "secp256k1",
+            # for ES384 algorithm
+            "ES384",
+            "secp384r1",
+            "P-384",
+            # for ES512 algorithm
+            "ES512",
+            "secp521r1",
+            "P-521",
+        ],
+    ) -> Self:
+        """Generate a new EC key pair.
+
+        Args:
+            curve: The elliptic curve to use. Can be an EllipticCurve instance,
+                   a curve name: "P-256", "P-384", "P-521", "secp256r1",
+                   "secp384r1", "secp521r1", "secp256k1",
+                   or an algorithm name: "ES256", "ES256K", "ES384", "ES512".
+        """
+        check_cryptography_available()
+
+        # Map string names to curve instances
+        if isinstance(curve, str):
+            curve_map = {
+                # Standard curve names
+                "P-256": ec.SECP256R1(),
+                "secp256r1": ec.SECP256R1(),
+                "P-384": ec.SECP384R1(),
+                "secp384r1": ec.SECP384R1(),
+                "P-521": ec.SECP521R1(),
+                "secp521r1": ec.SECP521R1(),
+                "secp256k1": ec.SECP256K1(),
+                # Algorithm names
+                "ES256": ec.SECP256R1(),
+                "ES256K": ec.SECP256K1(),
+                "ES384": ec.SECP384R1(),
+                "ES512": ec.SECP521R1(),
+            }
+            if curve not in curve_map:
+                raise SuperJWTError(
+                    f"Unsupported curve: {curve}. "
+                    f"Supported curves: {', '.join(curve_map.keys())}"
+                )
+            curve = curve_map[curve]
+        elif not isinstance(curve, ec.EllipticCurve):
+            raise SuperJWTError(
+                "curve must be an instance of EllipticCurve or a valid curve name"
+            )
+
+        private_key_obj = ec.generate_private_key(
+            cast("ec.EllipticCurve", curve), default_backend()
+        )
+
+        private_key_pem = private_key_obj.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        return cls.import_key(private_key=private_key_pem)
 
     @property
     def private_key_types(self) -> tuple[type, ...]:
@@ -448,6 +584,33 @@ class OKPKey(
     name = "OKP"
     description = "Octet Key Pair for EdDSA algorithms (Ed25519, Ed448)"
     algorithms = ("Ed25519", "Ed448")
+
+    @classmethod
+    def generate(cls, curve: Literal["Ed25519", "Ed448"]) -> Self:
+        """Generate a new OKP key pair.
+
+        Args:
+            curve: The EdDSA curve to use: "Ed25519" or "Ed448".
+        """
+        check_cryptography_available()
+
+        if curve == "Ed25519":
+            private_key_obj = ed25519.Ed25519PrivateKey.generate()
+        elif curve == "Ed448":
+            private_key_obj = ed448.Ed448PrivateKey.generate()
+        else:
+            raise SuperJWTError(
+                f"Unsupported OKP algorithm: {curve}. "
+                "Supported algorithms: Ed25519, Ed448"
+            )
+
+        private_key_pem = private_key_obj.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+        return cls.import_key(private_key=private_key_pem)
 
     @property
     def private_key_types(self) -> tuple[type, ...]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from superjwt.definitions import Alg, JWTClaims, JWTDatetime
 from superjwt.jws import JWS
 from superjwt.jwt import JWT
-from superjwt.keys import ECKey, OKPKey, RSAKey
+from superjwt.keys import AsymmetricKey, ECKey, OKPKey, RSAKey
 from superjwt.utils import check_cryptography_available
 
 
@@ -160,7 +160,7 @@ requires_cryptography = pytest.mark.skipif(
 if CRYPTOGRAPHY_AVAILABLE:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
+    from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 
 class KeyPair(BaseModel):
@@ -196,38 +196,24 @@ class KeyPair(BaseModel):
     # (RSAKey | ECKey | OKPKey)
     key_instance_from_public_pem: Any
 
+    @classmethod
+    def make_obj(cls, key: AsymmetricKey):
+        return KeyPair(
+            private_key_obj=key._private_key_obj,
+            public_key_obj=key._public_key_obj,
+            private_pem=key.private_key,
+            public_pem=key.public_key,
+            key_instance_from_private_pem=type(key).import_signing_key(key.private_key),
+            key_instance_from_public_pem=type(key).import_verifying_key(key.public_key),
+        )
+
 
 @pytest.fixture(scope="session")
 def rsa_2048_key_pair():
     """Generate RSA-2048 key pair once per session for all RSA tests."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    from superjwt.keys import RSAKey
-
-    private_key_obj = rsa.generate_private_key(
-        public_exponent=65537, key_size=2048, backend=default_backend()
-    )
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=RSAKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=RSAKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(RSAKey.generate(2048))
 
 
 @pytest.fixture(scope="session")
@@ -235,30 +221,7 @@ def rsa_2048_key_pair_alt():
     """Generate a second RSA-2048 key pair for wrong key tests."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = rsa.generate_private_key(
-        public_exponent=65537, key_size=2048, backend=default_backend()
-    )
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=RSAKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=RSAKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(RSAKey.generate(2048))
 
 
 @pytest.fixture(scope="session")
@@ -266,28 +229,7 @@ def ec_p256_key_pair():
     """Generate EC P-256 (SECP256R1) key pair once per session."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ec.generate_private_key(ec.SECP256R1(), default_backend())
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=ECKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=ECKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(ECKey.generate("P-256"))
 
 
 @pytest.fixture(scope="session")
@@ -295,28 +237,7 @@ def ec_p256_key_pair_alt():
     """Generate a second EC P-256 key pair for wrong key tests."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ec.generate_private_key(ec.SECP256R1(), default_backend())
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=ECKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=ECKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(ECKey.generate("P-256"))
 
 
 @pytest.fixture(scope="session")
@@ -324,28 +245,7 @@ def ec_p384_key_pair():
     """Generate EC P-384 (SECP384R1) key pair once per session."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ec.generate_private_key(ec.SECP384R1(), default_backend())
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=ECKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=ECKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(ECKey.generate("P-384"))
 
 
 @pytest.fixture(scope="session")
@@ -353,28 +253,7 @@ def ec_p521_key_pair():
     """Generate EC P-521 (SECP521R1) key pair once per session."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ec.generate_private_key(ec.SECP521R1(), default_backend())
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=ECKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=ECKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(ECKey.generate("P-521"))
 
 
 @pytest.fixture(scope="session")
@@ -382,28 +261,7 @@ def ed25519_key_pair():
     """Generate Ed25519 key pair once per session."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ed25519.Ed25519PrivateKey.generate()
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=OKPKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=OKPKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(OKPKey.generate("Ed25519"))
 
 
 @pytest.fixture(scope="session")
@@ -411,28 +269,7 @@ def ed25519_key_pair_alt():
     """Generate a second Ed25519 key pair for wrong key tests."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
-
-    private_key_obj = ed25519.Ed25519PrivateKey.generate()
-
-    private_pem = private_key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = private_key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=OKPKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=OKPKey.import_verifying_key(public_pem),
-    )
+    return KeyPair.make_obj(OKPKey.generate("Ed25519"))
 
 
 @pytest.fixture(scope="session")
@@ -440,25 +277,72 @@ def ed448_key_pair():
     """Generate Ed448 key pair once per session."""
     if not CRYPTOGRAPHY_AVAILABLE:
         pytest.skip("cryptography not available")
+    return KeyPair.make_obj(OKPKey.generate("Ed448"))
 
-    private_key_obj = ed448.Ed448PrivateKey.generate()
 
-    private_pem = private_key_obj.private_bytes(
+# Additional RSA key sizes for testing
+@pytest.fixture(scope="session")
+def rsa_3072_key_pair():
+    """Generate RSA-3072 key pair once per session."""
+    if not CRYPTOGRAPHY_AVAILABLE:
+        pytest.skip("cryptography not available")
+    return KeyPair.make_obj(RSAKey.generate(3072))
+
+
+@pytest.fixture(scope="session")
+def rsa_4096_key_pair():
+    """Generate RSA-4096 key pair once per session."""
+    if not CRYPTOGRAPHY_AVAILABLE:
+        pytest.skip("cryptography not available")
+    return KeyPair.make_obj(RSAKey.generate(4096))
+
+
+# Weak keys for security warning tests (session-scoped for performance)
+@pytest.fixture(scope="session")
+def rsa_1024_weak_key():
+    """Generate weak RSA-1024 key pair once per session for warning tests."""
+    if not CRYPTOGRAPHY_AVAILABLE:
+        pytest.skip("cryptography not available")
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=1024, backend=default_backend()
+    )
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return {"private_pem": private_pem, "public_pem": public_pem}
+
+
+@pytest.fixture(scope="session")
+def ec_p192_weak_key():
+    """Generate weak EC P-192 key pair once per session for warning tests."""
+    if not CRYPTOGRAPHY_AVAILABLE:
+        pytest.skip("cryptography not available")
+
+    private_key = ec.generate_private_key(ec.SECP192R1(), default_backend())
+    private_pem = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     )
+    return {"private_pem": private_pem}
 
-    public_pem = private_key_obj.public_key().public_bytes(
+
+@pytest.fixture(scope="session")
+def ec_p224_weak_key():
+    """Generate weak EC P-224 key pair once per session for warning tests."""
+    if not CRYPTOGRAPHY_AVAILABLE:
+        pytest.skip("cryptography not available")
+
+    private_key = ec.generate_private_key(ec.SECP224R1(), default_backend())
+    public_pem = private_key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
-
-    return KeyPair(
-        private_key_obj=private_key_obj,
-        public_key_obj=private_key_obj.public_key(),
-        private_pem=private_pem,
-        public_pem=public_pem,
-        key_instance_from_private_pem=OKPKey.import_signing_key(private_pem),
-        key_instance_from_public_pem=OKPKey.import_verifying_key(public_pem),
-    )
+    return {"public_pem": public_pem}

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -17,7 +17,7 @@ from superjwt.algorithms import (
     RS384Algorithm,
     RS512Algorithm,
 )
-from superjwt.exceptions import InvalidKeyError, SuperJWTError
+from superjwt.exceptions import SuperJWTError
 from superjwt.keys import ECKey, NoneKey, OctKey, OKPKey, RSAKey
 
 from .conftest import CRYPTOGRAPHY_AVAILABLE, requires_cryptography
@@ -303,12 +303,10 @@ class TestRSAAlgorithms:
 
     def test_rsa_sign_requires_private_key(self, rsa_key_pair, test_data):
         """Test that signing requires a private key."""
-        from superjwt.exceptions import InvalidKeyError
-
         algorithm = RS256Algorithm()
 
         # Try to sign with public key (should fail)
-        with pytest.raises(InvalidKeyError, match="private component"):
+        with pytest.raises(SuperJWTError, match="private component"):
             algorithm.sign(test_data, rsa_key_pair.key_instance_from_public_pem)
 
     def test_rsa_check_key_validates_type(self, rsa_key_pair):
@@ -723,7 +721,7 @@ class TestECDSAAlgorithms:
         algorithm = ES256Algorithm()
         public_key = ec_p256_key_pair.key_instance_from_public_pem
 
-        with pytest.raises(InvalidKeyError):
+        with pytest.raises(SuperJWTError):
             algorithm.sign(test_data, public_key)
 
     def test_ecdsa_check_key_validates_type(self, ec_p256_key_pair):
@@ -882,7 +880,7 @@ class TestEdDSAAlgorithms:
         algorithm = Ed25519Algorithm()
         public_key = ed25519_key_pair.key_instance_from_public_pem
 
-        with pytest.raises(InvalidKeyError):
+        with pytest.raises(SuperJWTError):
             algorithm.sign(test_data, public_key)
 
     def test_eddsa_check_key_validates_type(self, ed25519_key_pair):
@@ -995,3 +993,222 @@ class TestEdDSAAlgorithms:
         # Should raise error when trying to verify with Ed25519 algorithm (wrong curve)
         with pytest.raises(SuperJWTError, match=r"Key curve .* does not match"):
             ed25519_algo.verify(test_data, signature, ed448_public_only)
+
+
+class TestHMACGenerateKey:
+    """Test HMAC algorithm key generation."""
+
+    def test_hs256_generate_key_default_size(self):
+        """Test HS256 generates key with default size (32 bytes as hex = 64 chars)."""
+        algo = HS256Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 64  # 32 bytes as hex
+
+    def test_hs384_generate_key_default_size(self):
+        """Test HS384 generates key with default size (48 bytes as hex = 96 chars)."""
+        algo = HS384Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 96  # 48 bytes as hex
+
+    def test_hs512_generate_key_default_size(self):
+        """Test HS512 generates key with default size (64 bytes as hex = 128 chars)."""
+        algo = HS512Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 128  # 64 bytes as hex
+
+    def test_hmac_generate_key_custom_size(self):
+        """Test HMAC can generate key with custom size."""
+        algo = HS256Algorithm()
+        key = algo.generate_key(16)
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 32  # 16 bytes as hex
+
+    def test_hmac_generated_key_works_for_signing(self):
+        """Test that generated key can be used for signing and verification."""
+        algo = HS256Algorithm()
+        key = algo.generate_key()
+        test_data = b"test message"
+
+        signature = algo.sign(test_data, key)
+        assert algo.verify(test_data, signature, key)
+
+    def test_hmac_generated_keys_are_different(self):
+        """Test that multiple generated keys are different."""
+        algo = HS256Algorithm()
+        key1 = algo.generate_key()
+        key2 = algo.generate_key()
+        assert key1.private_key != key2.private_key
+
+
+@requires_cryptography
+class TestRSAGenerateKey:
+    """Test RSA algorithm key generation."""
+
+    def test_rs256_generate_key_2048(self):
+        """Test RS256 can generate 2048-bit key."""
+        algo = RS256Algorithm()
+        key = algo.generate_key(2048)
+        assert isinstance(key, RSAKey)
+        private_key = key._get_private_key()
+        assert private_key.key_size == 2048
+
+    def test_rs384_generate_key_3072(self):
+        """Test RS384 can generate 3072-bit key."""
+        algo = RS384Algorithm()
+        key = algo.generate_key(3072)
+        assert isinstance(key, RSAKey)
+        private_key = key._get_private_key()
+        assert private_key.key_size == 3072
+
+    def test_rs512_generate_key_4096(self):
+        """Test RS512 can generate 4096-bit key."""
+        algo = RS512Algorithm()
+        key = algo.generate_key(4096)
+        assert isinstance(key, RSAKey)
+        private_key = key._get_private_key()
+        assert private_key.key_size == 4096
+
+    def test_rsa_generated_key_works_for_signing(self):
+        """Test that generated RSA key can be used for signing and verification."""
+        algo = RS256Algorithm()
+        key = algo.generate_key(2048)
+        test_data = b"test message"
+
+        signature = algo.sign(test_data, key)
+        assert algo.verify(test_data, signature, key)
+
+
+@requires_cryptography
+class TestRSAPSSGenerateKey:
+    """Test RSA-PSS algorithm key generation."""
+
+    def test_ps256_generate_key(self):
+        """Test PS256 can generate key."""
+        algo = PS256Algorithm()
+        key = algo.generate_key(2048)
+        assert isinstance(key, RSAKey)
+        private_key = key._get_private_key()
+        assert private_key.key_size == 2048
+
+    def test_ps384_generate_key(self):
+        """Test PS384 can generate key."""
+        algo = PS384Algorithm()
+        key = algo.generate_key(2048)
+        assert isinstance(key, RSAKey)
+
+    def test_ps512_generate_key(self):
+        """Test PS512 can generate key."""
+        algo = PS512Algorithm()
+        key = algo.generate_key(2048)
+        assert isinstance(key, RSAKey)
+
+    def test_pss_generated_key_works_for_signing(self):
+        """Test that generated RSA-PSS key can be used for signing and verification."""
+        algo = PS256Algorithm()
+        key = algo.generate_key(2048)
+        test_data = b"test message"
+
+        signature = algo.sign(test_data, key)
+        assert algo.verify(test_data, signature, key)
+
+
+@requires_cryptography
+class TestECDSAGenerateKey:
+    """Test ECDSA algorithm key generation."""
+
+    def test_es256_generate_key(self):
+        """Test ES256 generates key with P-256 curve."""
+        algo = ES256Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, ECKey)
+        assert key.curve_name == "secp256r1"
+
+    def test_es256k_generate_key(self):
+        """Test ES256K generates key with secp256k1 curve."""
+        algo = ES256KAlgorithm()
+        key = algo.generate_key()
+        assert isinstance(key, ECKey)
+        assert key.curve_name == "secp256k1"
+
+    def test_es384_generate_key(self):
+        """Test ES384 generates key with P-384 curve."""
+        algo = ES384Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, ECKey)
+        assert key.curve_name == "secp384r1"
+
+    def test_es512_generate_key(self):
+        """Test ES512 generates key with P-521 curve."""
+        algo = ES512Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, ECKey)
+        assert key.curve_name == "secp521r1"
+
+    def test_ecdsa_generated_key_works_for_signing(self):
+        """Test that generated EC key can be used for signing and verification."""
+        algo = ES256Algorithm()
+        key = algo.generate_key()
+        test_data = b"test message"
+
+        signature = algo.sign(test_data, key)
+        assert algo.verify(test_data, signature, key)
+
+    def test_ecdsa_generated_signatures_are_different(self):
+        """Test that ECDSA produces different signatures (randomization)."""
+        algo = ES256Algorithm()
+        key = algo.generate_key()
+        test_data = b"test message"
+
+        signature1 = algo.sign(test_data, key)
+        signature2 = algo.sign(test_data, key)
+        # ECDSA signatures should be different due to random nonce
+        assert signature1 != signature2
+        # But both should verify
+        assert algo.verify(test_data, signature1, key)
+        assert algo.verify(test_data, signature2, key)
+
+
+@requires_cryptography
+class TestEdDSAGenerateKey:
+    """Test EdDSA algorithm key generation."""
+
+    def test_ed25519_generate_key(self):
+        """Test Ed25519 can generate key."""
+        algo = Ed25519Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, OKPKey)
+        # Verify it's Ed25519 by checking the key type
+        private_key = key._get_private_key()
+        assert type(private_key).__name__ == "Ed25519PrivateKey"
+
+    def test_ed448_generate_key(self):
+        """Test Ed448 can generate key."""
+        algo = Ed448Algorithm()
+        key = algo.generate_key()
+        assert isinstance(key, OKPKey)
+        # Verify it's Ed448 by checking the key type
+        private_key = key._get_private_key()
+        assert type(private_key).__name__ == "Ed448PrivateKey"
+
+    def test_eddsa_generated_key_works_for_signing(self):
+        """Test that generated EdDSA key can be used for signing and verification."""
+        algo = Ed25519Algorithm()
+        key = algo.generate_key()
+        test_data = b"test message"
+
+        signature = algo.sign(test_data, key)
+        assert algo.verify(test_data, signature, key)
+
+    def test_eddsa_signatures_are_deterministic(self):
+        """Test that EdDSA produces deterministic signatures."""
+        algo = Ed25519Algorithm()
+        key = algo.generate_key()
+        test_data = b"test message"
+
+        signature1 = algo.sign(test_data, key)
+        signature2 = algo.sign(test_data, key)
+        # EdDSA signatures should be identical (deterministic)
+        assert signature1 == signature2

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -6,11 +6,11 @@ from superjwt.definitions import Alg, JWTClaims, Key
 from superjwt.exceptions import (
     AlgorithmNotSupportedError,
     InvalidAlgorithmError,
-    InvalidKeyError,
+    SuperJWTError,
     TokenExpiredError,
     TokenNotYetValidError,
 )
-from superjwt.keys import ECKey, NoneKey, OctKey, OKPKey, RSAKey
+from superjwt.keys import ECKey, OctKey, OKPKey, RSAKey
 
 from .conftest import (
     JWTCustomClaims,
@@ -628,6 +628,26 @@ class TestAlgEnum:
         assert instance is not None
         assert instance.__class__.__name__ == "HS256Algorithm"
 
+    def test_get_algorithm_with_enum(self):
+        """Test that get_algorithm() handles Alg enum values."""
+        instance = Alg.get_algorithm(Alg.HS256)
+        assert instance is not None
+        assert instance.__class__.__name__ == "HS256Algorithm"
+
+    def test_get_algorithm_with_string(self):
+        """Test that get_algorithm() handles string algorithm names."""
+        instance = Alg.get_algorithm("HS256")
+        assert instance is not None
+        assert instance.__class__.__name__ == "HS256Algorithm"
+
+    def test_get_algorithm_with_instance(self):
+        """Test that get_algorithm() passes through algorithm instances."""
+        from superjwt.algorithms import HS256Algorithm
+
+        original_instance = HS256Algorithm()
+        returned_instance = Alg.get_algorithm(original_instance)
+        assert returned_instance is original_instance
+
 
 class TestKeyEnum:
     """Test suite for the Key enum static methods."""
@@ -639,25 +659,11 @@ class TestKeyEnum:
         assert key.private_key == b"secret"
         assert key.public_key == b""
 
-    def test_make_key_with_none_algorithm(self):
-        """Test Key.make_key() with 'none' algorithm."""
-        key = Key.make_key("none", private_key=None, public_key=None)
-        assert isinstance(key, NoneKey)
-        assert key.private_key == b""
-        assert key.public_key == b""
-
     def test_make_signing_key_with_symmetric_algorithm(self):
         """Test Key.make_signing_key() with symmetric algorithm (HMAC)."""
         key = Key.make_signing_key("HS256", b"secret")
         assert isinstance(key, OctKey)
         assert key.private_key == b"secret"
-        assert key.public_key == b""
-
-    def test_make_signing_key_with_none_algorithm(self):
-        """Test Key.make_signing_key() with 'none' algorithm."""
-        key = Key.make_signing_key("none", b"")
-        assert isinstance(key, NoneKey)
-        assert key.private_key == b""
         assert key.public_key == b""
 
     def test_make_verifying_key_with_symmetric_algorithm(self):
@@ -667,17 +673,10 @@ class TestKeyEnum:
         assert key.private_key == b"secret"
         assert key.public_key == b""
 
-    def test_make_verifying_key_with_none_algorithm(self):
-        """Test Key.make_verifying_key() with 'none' algorithm."""
-        key = Key.make_verifying_key("none", b"")
-        assert isinstance(key, NoneKey)
-        assert key.private_key == b""
-        assert key.public_key == b""
-
     def test_make_key_with_symmetric_algorithm_and_public_key_raises_error(self):
         """Test Key.make_key() with symmetric algorithm and public_key raises InvalidKeyError."""
         with pytest.raises(
-            InvalidKeyError, match=r"Symmetric key should not have a public key component"
+            SuperJWTError, match=r"Symmetric key should not have a public key component"
         ):
             Key.make_key("HS256", private_key=b"secret", public_key=b"invalid")
 

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -1,4 +1,5 @@
 import pytest
+from superjwt.algorithms import NoneAlgorithm
 from superjwt.definitions import JOSEHeader, Validation
 from superjwt.exceptions import (
     AlgorithmMismatchError,
@@ -82,7 +83,11 @@ def test_wrong_header_algorithm(
 
 
 def test_none_algorithm_not_allowed_decode():
-    """Test that decoding with 'none' algorithm raises error when not explicitly allowed."""
+    """Test that decoding with 'none' algorithm raises error when not explicitly allowed.
+
+    Note: NoneAlgorithm is used internally for inspect() functionality but not exposed
+    in the public Alg enum.
+    """
 
     none_token = (
         "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
@@ -92,7 +97,7 @@ def test_none_algorithm_not_allowed_decode():
         "ZHVtbXk"
     )
 
-    jws_none = JWS(algorithm="none")
+    jws_none = JWS(algorithm=NoneAlgorithm())
     none_key = NoneKey()
 
     # Test decode with none algorithm not allowed
@@ -107,8 +112,12 @@ def test_none_algorithm_not_allowed_decode():
 
 
 def test_none_algorithm_not_allowed_encode(claims_fixed_dt: JWTCustomClaims):
-    """Test that encoding with 'none' algorithm raises error when not explicitly allowed."""
-    jws_none = JWS(algorithm="none")
+    """Test that encoding with 'none' algorithm raises error when not explicitly allowed.
+
+    Note: NoneAlgorithm is used internally for inspect() functionality but not exposed
+    in the public Alg enum.
+    """
+    jws_none = JWS(algorithm=NoneAlgorithm())
     none_key = NoneKey()
 
     # Test encode with none algorithm not allowed

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -14,6 +14,7 @@ from superjwt.definitions import (
     JWTDatetimeFloat,
     JWTDatetimeInt,
     JWTValidation,
+    Key,
     Validation,
 )
 from superjwt.exceptions import (
@@ -1068,8 +1069,6 @@ def test_hmac_algorithms(jwt: JWT, claims: JWTCustomClaims, secret_key: str):
 @requires_cryptography
 def test_rsa_pkcs1_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pair):
     """Test RSA PKCS#1 v1.5 algorithms with different key usage patterns."""
-    from superjwt.definitions import Key
-
     rsa_algorithms = [Alg.RS256, Alg.RS384, Alg.RS512]
 
     for alg in rsa_algorithms:
@@ -1113,8 +1112,6 @@ def test_rsa_pkcs1_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pa
 @requires_cryptography
 def test_rsa_pss_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pair):
     """Test RSA-PSS algorithms with different key usage patterns."""
-    from superjwt.definitions import Key
-
     rsa_pss_algorithms = [Alg.PS256, Alg.PS384, Alg.PS512]
 
     for alg in rsa_pss_algorithms:
@@ -1164,8 +1161,6 @@ def test_ecdsa_algorithms(
     ec_p521_key_pair,
 ):
     """Test ECDSA algorithms with different key usage patterns."""
-    from superjwt.definitions import Key
-
     # Map algorithms to their corresponding key pairs
     ecdsa_test_cases = [
         (Alg.ES256, ec_p256_key_pair),
@@ -1210,8 +1205,6 @@ def test_eddsa_algorithms(
     jwt: JWT, claims: JWTCustomClaims, ed25519_key_pair, ed448_key_pair
 ):
     """Test EdDSA algorithms with different key usage patterns."""
-    from superjwt.definitions import Key
-
     # Map algorithms to their corresponding key pairs
     eddsa_test_cases = [
         (Alg.Ed25519, ed25519_key_pair),

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,7 +1,9 @@
 """Tests for superjwt.keys module."""
 
+import warnings
+
 import pytest
-from superjwt.exceptions import InvalidKeyError, KeyLengthSecurityWarning
+from superjwt.exceptions import InvalidKeyError, KeyLengthSecurityWarning, SuperJWTError
 from superjwt.keys import ECKey, NoneKey, OctKey, OKPKey, RSAKey
 from superjwt.utils import check_cryptography_available
 
@@ -122,8 +124,6 @@ MIIEpAIBAAKCAQEA4Z9v...
 
     def test_oct_key_sufficient_length(self):
         """Test that sufficiently long keys don't trigger warnings."""
-        import warnings
-
         # 14 bytes = 112 bits (minimum)
         secret = b"a" * 14
         with warnings.catch_warnings(record=True) as warning_list:
@@ -153,6 +153,49 @@ MIIEpAIBAAKCAQEA4Z9v...
         """Test that empty public_key parameter raises ValueError."""
         with pytest.raises(ValueError, match="Secret key must not be empty"):
             OctKey.import_key(None, b"")
+
+    def test_oct_key_generate_default_size(self):
+        """Test OctKey.generate() with default size (32 bytes as hex = 64 chars)."""
+        key = OctKey.generate()
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 64  # 32 bytes as hex = 64 characters
+
+    def test_oct_key_generate_default_size_raw_bytes(self):
+        """Test OctKey.generate() with default size and raw bytes."""
+        key = OctKey.generate(human_readable=False)
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 32  # 32 bytes raw
+
+    def test_oct_key_generate_custom_size(self):
+        """Test OctKey.generate() with custom size."""
+        key = OctKey.generate(64)
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 128  # 64 bytes as hex = 128 characters
+
+    def test_oct_key_generate_custom_size_raw_bytes(self):
+        """Test OctKey.generate() with custom size and raw bytes."""
+        key = OctKey.generate(64, human_readable=False)
+        assert isinstance(key, OctKey)
+        assert len(key.private_key) == 64  # 64 bytes raw
+
+    def test_oct_key_generate_creates_different_keys(self):
+        """Test that OctKey.generate() creates different keys each time."""
+        key1 = OctKey.generate(32)
+        key2 = OctKey.generate(32)
+        assert key1.private_key != key2.private_key
+
+    def test_oct_key_generated_key_is_usable(self):
+        """Test that generated key can be used for HMAC operations."""
+        key = OctKey.generate(32)
+        # Test with HMAC algorithm
+        import hashlib
+        import hmac
+
+        test_data = b"test message"
+        signature = hmac.new(key.private_key, test_data, hashlib.sha256).digest()
+        # Verify the signature
+        expected = hmac.new(key.private_key, test_data, hashlib.sha256).digest()
+        assert hmac.compare_digest(signature, expected)
 
 
 @requires_cryptography
@@ -241,11 +284,9 @@ class TestRSAKey:
         self, rsa_public_key_spki
     ):
         """Test that getting private key from public-only key raises error."""
-        from superjwt.keys import RSAKey
-
         key = RSAKey.import_key(public_key=rsa_public_key_spki)
         with pytest.raises(
-            InvalidKeyError, match="does not have a private component for signing"
+            SuperJWTError, match="does not have a private component for signing"
         ):
             key._get_private_key()
 
@@ -253,7 +294,7 @@ class TestRSAKey:
         """Test that calling get_public_key() on an uninitialized key raises error."""
         key = RSAKey()
         with pytest.raises(
-            InvalidKeyError, match="does not have a public component for verification"
+            SuperJWTError, match="does not have a public component for verification"
         ):
             key._get_public_key()
 
@@ -384,40 +425,21 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
         with pytest.raises(InvalidKeyError, match=r"Key must be an RSA public key"):
             RSAKey.import_key(public_key=ec_public_key_pem)
 
-    def test_rsa_key_small_key_warning_private(self):
+    def test_rsa_key_small_key_warning_private(self, rsa_1024_weak_key):
         """Test that small RSA private key triggers security warning."""
-        # Generate a small 1024-bit key
-        small_private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=1024, backend=default_backend()
-        )
-        small_private_pem = small_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-
         with pytest.warns(
             KeyLengthSecurityWarning,
             match=r"RSA key size is 1024 bits.*should be >= 2048 bits",
         ):
-            RSAKey.import_key(small_private_pem)
+            RSAKey.import_key(rsa_1024_weak_key["private_pem"])
 
-    def test_rsa_key_small_key_warning_public(self):
+    def test_rsa_key_small_key_warning_public(self, rsa_1024_weak_key):
         """Test that small RSA public key triggers security warning."""
-        # Generate a small 1024-bit key
-        small_private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=1024, backend=default_backend()
-        )
-        small_public_pem = small_private_key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-
         with pytest.warns(
             KeyLengthSecurityWarning,
             match=r"RSA key size is 1024 bits.*should be >= 2048 bits",
         ):
-            RSAKey.import_key(public_key=small_public_pem)
+            RSAKey.import_key(public_key=rsa_1024_weak_key["public_pem"])
 
     def test_rsa_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
@@ -450,6 +472,22 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
         assert isinstance(public_key_obj1, rsa.RSAPublicKey)
         assert isinstance(public_key_obj2, rsa.RSAPublicKey)
         assert key.public_keys_match(public_key_obj1, public_key_obj2) is False
+
+    def test_rsa_key_export_private_key_pem(self, rsa_2048_key_pair):
+        """Test exporting private key as PEM."""
+        key = rsa_2048_key_pair.key_instance_from_private_pem
+        pem = key.export_private_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PRIVATE KEY" in pem
+
+    def test_rsa_key_export_public_key_pem(self, rsa_2048_key_pair):
+        """Test exporting public key as PEM."""
+        key = rsa_2048_key_pair.key_instance_from_private_pem
+        pem = key.export_public_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PUBLIC KEY" in pem
 
 
 @requires_cryptography
@@ -529,7 +567,7 @@ class TestECKey:
         """Test that getting private key from public-only key raises error."""
         key = ECKey.import_key(public_key=ec_public_key_p256)
         with pytest.raises(
-            InvalidKeyError, match="does not have a private component for signing"
+            SuperJWTError, match="does not have a private component for signing"
         ):
             key._get_private_key()
 
@@ -537,7 +575,7 @@ class TestECKey:
         """Test that calling get_public_key() on an uninitialized key raises error."""
         key = ECKey()
         with pytest.raises(
-            InvalidKeyError, match="does not have a public component for verification"
+            SuperJWTError, match="does not have a public component for verification"
         ):
             key._get_public_key()
 
@@ -664,36 +702,21 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
         with pytest.raises(InvalidKeyError, match=r"Key must be an EC public key"):
             ECKey.import_key(public_key=rsa_public_key_pem)
 
-    def test_ec_key_small_curve_warning_private(self):
+    def test_ec_key_small_curve_warning_private(self, ec_p192_weak_key):
         """Test that small EC curve private key triggers security warning."""
-        # Generate a key with P-192 (weak curve)
-        small_private_key = ec.generate_private_key(ec.SECP192R1(), default_backend())
-        small_private_pem = small_private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-
         with pytest.warns(
             KeyLengthSecurityWarning,
             match=r"EC curve.*has weak security",
         ):
-            ECKey.import_key(small_private_pem)
+            ECKey.import_key(ec_p192_weak_key["private_pem"])
 
-    def test_ec_key_small_curve_warning_public(self):
+    def test_ec_key_small_curve_warning_public(self, ec_p224_weak_key):
         """Test that small EC curve public key triggers security warning."""
-        # Generate a key with P-224 (weak curve)
-        small_private_key = ec.generate_private_key(ec.SECP224R1(), default_backend())
-        small_public_pem = small_private_key.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-
         with pytest.warns(
             KeyLengthSecurityWarning,
             match=r"EC curve.*has weak security",
         ):
-            ECKey.import_key(public_key=small_public_pem)
+            ECKey.import_key(public_key=ec_p224_weak_key["public_pem"])
 
     def test_ec_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
@@ -726,6 +749,42 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
         assert isinstance(public_key_obj1, ec.EllipticCurvePublicKey)
         assert isinstance(public_key_obj2, ec.EllipticCurvePublicKey)
         assert key.public_keys_match(public_key_obj1, public_key_obj2) is False
+
+    def test_ec_key_generate_with_invalid_curve_string(self):
+        """Test that ECKey.generate() raises error for invalid curve string."""
+        with pytest.raises(SuperJWTError, match="Unsupported curve"):
+            ECKey.generate("INVALID-CURVE")  # type: ignore
+
+    def test_ec_key_generate_with_invalid_type(self):
+        """Test that ECKey.generate() raises error for invalid curve type."""
+        with pytest.raises(SuperJWTError, match="curve must be an instance"):
+            ECKey.generate(123)  # type: ignore
+
+    def test_ec_key_export_private_key_pem(self, ec_p256_key_pair):
+        """Test exporting private key as PEM."""
+        key = ec_p256_key_pair.key_instance_from_private_pem
+        pem = key.export_private_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PRIVATE KEY" in pem
+
+    def test_ec_key_export_public_key_pem(self, ec_p256_key_pair):
+        """Test exporting public key as PEM."""
+        key = ec_p256_key_pair.key_instance_from_private_pem
+        pem = key.export_public_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PUBLIC KEY" in pem
+
+    def test_ec_key_curve_name_from_public_only(self, ec_public_key_p256):
+        """Test getting curve name from public-only key."""
+        key = ECKey.import_key(public_key=ec_public_key_p256)
+        assert key.curve_name == "secp256r1"
+
+    def test_ec_key_curve_key_size_from_public_only(self, ec_public_key_p256):
+        """Test getting curve key size from public-only key."""
+        key = ECKey.import_key(public_key=ec_public_key_p256)
+        assert key.curve_key_size == 256
 
 
 @requires_cryptography
@@ -793,7 +852,7 @@ class TestOKPKey:
         """Test that getting private key from public-only key raises error."""
         key = OKPKey.import_key(public_key=okp_public_key_ed25519)
         with pytest.raises(
-            InvalidKeyError, match="does not have a private component for signing"
+            SuperJWTError, match="does not have a private component for signing"
         ):
             key._get_private_key()
 
@@ -801,7 +860,7 @@ class TestOKPKey:
         """Test that calling get_public_key() on an uninitialized key raises error."""
         key = OKPKey()
         with pytest.raises(
-            InvalidKeyError, match="does not have a public component for verification"
+            SuperJWTError, match="does not have a public component for verification"
         ):
             key._get_public_key()
 
@@ -972,3 +1031,24 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
             public_key_obj2, (ed25519.Ed25519PublicKey, ed448.Ed448PublicKey)
         )
         assert key.public_keys_match(public_key_obj1, public_key_obj2) is False
+
+    def test_okp_key_generate_with_invalid_algorithm(self):
+        """Test that OKPKey.generate() raises error for invalid algorithm."""
+        with pytest.raises(SuperJWTError, match="Unsupported OKP algorithm"):
+            OKPKey.generate("Ed519")  # type: ignore
+
+    def test_okp_key_export_private_key_pem(self, ed25519_key_pair):
+        """Test exporting private key as PEM."""
+        key = ed25519_key_pair.key_instance_from_private_pem
+        pem = key.export_private_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PRIVATE KEY" in pem
+
+    def test_okp_key_export_public_key_pem(self, ed25519_key_pair):
+        """Test exporting public key as PEM."""
+        key = ed25519_key_pair.key_instance_from_private_pem
+        pem = key.export_public_key_pem()
+
+        assert isinstance(pem, bytes)
+        assert b"BEGIN PUBLIC KEY" in pem


### PR DESCRIPTION
Generate keys from `BaseJWSAlgorithm` instance:

```python
from superjwt import Alg
from superjwt.exceptions import AlgorithmNotSupportedError

algs = [getattr(Alg, a) for a in Alg.__members__.keys()]

for alg in algs:
    try:
        jws_alg = alg.get_instance()
        key = jws_alg.generate_key()
        print(alg, key.name, key.private_key, key.public_key)
    except AlgorithmNotSupportedError:
        print(alg, "not supported")
```

or generate directly from `BaseKey` instance:

```python
from superjwt import ECKey, OctKey, OKPKey, RSAKey 

keys_ = (
    (OctKey, 32),
    (OctKey, 48),
    (OctKey, 64),
    (RSAKey, 2048),
    (RSAKey, 3072),
    (RSAKey, 4096),
    (ECKey, "P-256"),
    (ECKey, "P-384"),
    (ECKey, "P-521"),
    (OKPKey, "Ed25519"),
    (OKPKey, "Ed448"),
)

for key_type, param in keys_:
    key = key_type.generate(param)
    print(key_type.__name__, key.private_key, key.public_key)
```
