### PR TITLE
refactor: rename JWTValidation to ValidationConfig

### DIFF
--- a/superjwt/__init__.py
+++ b/superjwt/__init__.py
@@ -12,8 +12,8 @@ from superjwt.validations import (
     JWTDatetime,
     JWTDatetimeFloat,
     JWTDatetimeInt,
-    JWTValidation,
     Validation,
+    ValidationConfig,
 )
 
 
@@ -28,11 +28,11 @@ __all__ = [
     "JWTDatetime",
     "JWTDatetimeFloat",
     "JWTDatetimeInt",
-    "JWTValidation",
     "OKPKey",
     "OctKey",
     "RSAKey",
     "Validation",
+    "ValidationConfig",
     "__version__",
     "decode",
     "encode",
@@ -48,11 +48,11 @@ def encode(
     headers: JOSEHeader | dict[str, Any] | None = None,
     detach_payload: bool = False,
     claims_validation: type[JWTBaseModel]
-    | JWTValidation
+    | ValidationConfig
     | Validation
     | None = Validation.DEFAULT,
     headers_validation: type[JOSEHeader]
-    | JWTValidation
+    | ValidationConfig
     | Validation
     | None = Validation.DEFAULT,
 ) -> bytes:
@@ -101,11 +101,11 @@ def decode(
     *,
     with_detached_payload: JWTClaims | dict[str, Any] | None = None,
     claims_validation: type[JWTBaseModel]
-    | JWTValidation
+    | ValidationConfig
     | Validation
     | None = Validation.DEFAULT,
     headers_validation: type[JOSEHeader]
-    | JWTValidation
+    | ValidationConfig
     | Validation
     | None = Validation.DEFAULT,
 ) -> dict[str, Any]:

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -21,8 +21,8 @@ from superjwt.validations import (
     JOSEHeader,
     JWTBaseModel,
     JWTHeadersDefaultValidation,
-    JWTValidation,
     Validation,
+    ValidationConfig,
     get_validation_config,
 )
 
@@ -35,7 +35,7 @@ class JWS:
         self,
         algorithm: Alg | BaseJWSAlgorithm | str,
         max_token_bytes: int = MAX_TOKEN_BYTES,
-        default_headers_validation: JWTValidation = JWTHeadersDefaultValidation,
+        default_headers_validation: ValidationConfig = JWTHeadersDefaultValidation,
     ):
         self.token: JWSTokenLifeCycle = JWSTokenLifeCycle()
         self.algorithm: BaseJWSAlgorithm[Key] = Alg.get_algorithm(algorithm)
@@ -64,7 +64,7 @@ class JWS:
         key: Key | bytes | str,
         *,
         headers_validation: type[JOSEHeader]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
     ) -> "JWSToken":
@@ -123,7 +123,7 @@ class JWS:
         *,
         with_detached_payload: dict[str, Any] | None = None,
         headers_validation: type[JOSEHeader]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
     ) -> "JWSToken":
@@ -254,7 +254,9 @@ class JWS:
         self.algorithm.check_key(key)
         return key
 
-    def validate_headers_and_algorithm(self, headers_validation: JWTValidation) -> None:
+    def validate_headers_and_algorithm(
+        self, headers_validation: ValidationConfig
+    ) -> None:
         # validate headers
         try:
             headers_validation.run(self.token.unsafe.headers)
@@ -295,8 +297,8 @@ class JWS:
     def get_headers_validation(
         self,
         data: JOSEHeader | dict[str, Any],
-        validation: type[JOSEHeader] | JWTValidation | Validation | None,
-    ) -> JWTValidation:
+        validation: type[JOSEHeader] | ValidationConfig | Validation | None,
+    ) -> ValidationConfig:
         return get_validation_config(
             data,
             validation,

--- a/superjwt/jwt.py
+++ b/superjwt/jwt.py
@@ -12,8 +12,8 @@ from superjwt.validations import (
     JWTBaseModel,
     JWTClaimsDefaultValidation,
     JWTHeadersDefaultValidation,
-    JWTValidation,
     Validation,
+    ValidationConfig,
     get_validation_config,
 )
 
@@ -25,8 +25,8 @@ class JWT:
     def __init__(
         self,
         max_token_bytes: int = MAX_TOKEN_BYTES,
-        default_claims_validation: JWTValidation = JWTClaimsDefaultValidation,
-        default_headers_validation: JWTValidation = JWTHeadersDefaultValidation,
+        default_claims_validation: ValidationConfig = JWTClaimsDefaultValidation,
+        default_headers_validation: ValidationConfig = JWTHeadersDefaultValidation,
     ) -> None:
         self.jws: JWS
 
@@ -42,11 +42,11 @@ class JWT:
         *,
         headers: JOSEHeader | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
         headers_validation: type[JOSEHeader]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -124,11 +124,11 @@ class JWT:
         *,
         with_detached_payload: JWTBaseModel | dict[str, Any] | None = None,
         claims_validation: type[JWTBaseModel]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
         headers_validation: type[JOSEHeader]
-        | JWTValidation
+        | ValidationConfig
         | Validation
         | None = Validation.DEFAULT,
     ) -> JWSToken:
@@ -237,8 +237,8 @@ class JWT:
     def get_claims_validation(
         self,
         data: JWTBaseModel | dict[str, Any],
-        validation: type[JWTBaseModel] | JWTValidation | Validation | None,
-    ) -> JWTValidation:
+        validation: type[JWTBaseModel] | ValidationConfig | Validation | None,
+    ) -> ValidationConfig:
         return get_validation_config(
             data,
             validation,

--- a/superjwt/validations.py
+++ b/superjwt/validations.py
@@ -331,7 +331,7 @@ class JWTClaims(JWTClaimsModel):
         return self.model_copy(update={"exp": exp_time})
 
 
-class JWTValidation(BaseModel):
+class ValidationConfig(BaseModel):
     """JWT data validation object."""
 
     model_config = {"extra": "forbid"}
@@ -341,15 +341,13 @@ class JWTValidation(BaseModel):
     enabled: bool = True
 
     """The pydantic model to use for data validation."""
-    validation_model: type[JWTBaseModel] | None = None
+    model: type[JWTBaseModel] | None = None
 
     """Forward the data pydantic model to validation config (and its internal config)."""
     forward_pydantic_model: bool = True
 
     """The default pydantic model to use for data storage when data is a dict."""
-    data_model: type[JWTBaseModel] = Field(
-        default_factory=lambda data: data["validation_model"]
-    )
+    data_model: type[JWTBaseModel] = Field(default_factory=lambda data: data["model"])
 
     # ------------- JWTBaseModel specific internal config -------------
     """Spoofed 'now' datetime."""
@@ -377,9 +375,7 @@ class JWTValidation(BaseModel):
         """Get internal config values as a dict for injection into validation."""
         internal_config = {}
         for param, model_type, _ in self._internal_params_matrix():
-            if self.validation_model is not None and issubclass(
-                self.validation_model, model_type
-            ):
+            if self.model is not None and issubclass(self.model, model_type):
                 value = getattr(self, param)
                 if value is not None:
                     internal_config[f"internal__{param}"] = value
@@ -399,7 +395,7 @@ class JWTValidation(BaseModel):
         if self.enabled is False:
             return data.to_dict() if isinstance(data, JWTBaseModel) else data
 
-        if self.validation_model is None:
+        if self.model is None:
             raise ValueError("Validation model is not set in JWTValidation")
 
         # case pydantic model
@@ -414,20 +410,20 @@ class JWTValidation(BaseModel):
             raise TypeError("Wrong type during data preparation and validation")
 
         ##### BEGIN VALIDATION #####
-        self.validation_model.model_validate(data_dict | self._get_internal_cfg())
+        self.model.model_validate(data_dict | self._get_internal_cfg())
         ##### END VALIDATION #####
 
         return data_dict
 
 
-JWTClaimsDefaultValidation = JWTValidation(
-    validation_model=JWTBaseModel,
+JWTClaimsDefaultValidation = ValidationConfig(
+    model=JWTBaseModel,
 )
-JWTClaimsStrictValidation = JWTValidation(
-    validation_model=JWTClaims,
+JWTClaimsStrictValidation = ValidationConfig(
+    model=JWTClaims,
 )
-JWTHeadersDefaultValidation = JWTValidation(
-    validation_model=JOSEHeader,
+JWTHeadersDefaultValidation = ValidationConfig(
+    model=JOSEHeader,
 )
 
 
@@ -440,13 +436,13 @@ class Validation(Enum):
 
 def get_data_model(
     data: JWTBaseModel | dict[str, Any],
-    validation: type[JWTBaseModel] | JWTValidation | Validation | None,
-    default_validation: JWTValidation,
+    validation: type[JWTBaseModel] | ValidationConfig | Validation | None,
+    default_validation: ValidationConfig,
     fallback_model: type[JWTBaseModel],
 ) -> type[JWTBaseModel]:
     if validation is Validation.DEFAULT and isinstance(data, dict):
         return default_validation.data_model
-    elif isinstance(validation, JWTValidation):
+    elif isinstance(validation, ValidationConfig):
         if validation.data_model is None:
             return fallback_model
         return validation.data_model
@@ -463,10 +459,10 @@ def get_data_model(
 
 def get_validation_config(
     data: JWTBaseModel | dict[str, Any],
-    validation: type[JWTBaseModel] | JWTValidation | Validation | None,
-    default_validation: JWTValidation,
+    validation: type[JWTBaseModel] | ValidationConfig | Validation | None,
+    default_validation: ValidationConfig,
     fallback_data_model: type[JWTBaseModel],
-) -> JWTValidation:
+) -> ValidationConfig:
     data_model = get_data_model(data, validation, default_validation, fallback_data_model)
 
     ##############################
@@ -474,9 +470,9 @@ def get_validation_config(
     if (
         validation is Validation.DISABLE
         or validation is None
-        or (isinstance(validation, JWTValidation) and validation.enabled is False)
+        or (isinstance(validation, ValidationConfig) and validation.enabled is False)
     ):
-        return JWTValidation(enabled=False, data_model=data_model)
+        return ValidationConfig(enabled=False, data_model=data_model)
 
     ##############################
     # case validation is ENABLED
@@ -489,30 +485,30 @@ def get_validation_config(
             if validation_cfg.forward_pydantic_model is True:
                 # ALWAYS forward data model to validation model in DEFAULT case
                 # --> the validation model was a mere fallback for dict data
-                validation_cfg.validation_model = None  # we will forward the model below
+                validation_cfg.model = None  # we will forward the model below
 
     # 2. case CUSTOM
-    elif isinstance(validation, JWTValidation) or (
+    elif isinstance(validation, ValidationConfig) or (
         isclass(validation) and issubclass(validation, JWTBaseModel)
     ):
         # 2.1 case JWTValidation instance
-        if isinstance(validation, JWTValidation):
+        if isinstance(validation, ValidationConfig):
             # make a copy, mutable object!!
             validation_cfg = validation.model_copy(deep=True)
 
         # 2.2 case Pydantic model
         if isclass(validation) and issubclass(validation, JWTBaseModel):
-            validation_cfg = JWTValidation(validation_model=validation)
+            validation_cfg = ValidationConfig(model=validation)
 
     else:
         raise TypeError("Wrong validation object type")
 
     # finalize internal config
     if isinstance(data, JWTBaseModel):
-        if validation_cfg.validation_model is None:
+        if validation_cfg.model is None:
             if validation_cfg.forward_pydantic_model is True:
                 # forward data model type to validation model
-                validation_cfg.validation_model = type(data)
+                validation_cfg.model = type(data)
                 # forward internal config from data model
                 validation_cfg.apply_internal_cfg(data)
             else:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -28,8 +28,8 @@ from superjwt.validations import (
     JWTDatetime,
     JWTDatetimeFloat,
     JWTDatetimeInt,
-    JWTValidation,
     Validation,
+    ValidationConfig,
 )
 
 from .conftest import JWTCustomClaims, check_claims_instance, requires_cryptography
@@ -702,8 +702,8 @@ def test_custom_default_claims_validation_policy(
     """Test JWT instance with custom default claims validation policy."""
 
     # Create JWT instance with strict claims validation by default (JWTClaims)
-    custom_validation_config = JWTValidation(
-        validation_model=JWTClaims,
+    custom_validation_config = ValidationConfig(
+        model=JWTClaims,
         data_model=JWTClaims,
     )
     jwt_strict = JWT(default_claims_validation=custom_validation_config)
@@ -766,8 +766,8 @@ def test_custom_default_headers_validation_policy(secret_key: str):
         custom_header: str
 
     # Create JWT instance with custom headers validation by default
-    custom_validation_config = JWTValidation(
-        validation_model=CustomHeader,
+    custom_validation_config = ValidationConfig(
+        model=CustomHeader,
         data_model=CustomHeader,
     )
     jwt_custom = JWT(default_headers_validation=custom_validation_config)
@@ -812,8 +812,8 @@ def test_custom_default_claims_validation_policy_no_force_pydantic(
     """Test JWT instance with custom default validation but force_validation_on_pydantic_model=False."""
 
     # Create JWT instance with custom validation but without forcing Pydantic validation
-    custom_validation_config = JWTValidation(
-        validation_model=JWTClaims,  # Validate against JWTClaims
+    custom_validation_config = ValidationConfig(
+        model=JWTClaims,  # Validate against JWTClaims
         forward_pydantic_model=False,  # Don't force Pydantic model type
         data_model=JWTBaseModel,
     )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,8 +19,8 @@ from superjwt.validations import (
     DEFAULT_LEEWAY_SECONDS,
     JWTBaseModel,
     JWTClaims,
-    JWTValidation,
     Validation,
+    ValidationConfig,
     get_validation_config,
 )
 
@@ -624,10 +624,10 @@ def test_unserialized_datetime(claims_dict: dict[str, Any]):
 
 def test_jwtvalidation_default_initialization():
     """Test JWTValidation with default initialization."""
-    validation = JWTValidation()
+    validation = ValidationConfig()
 
     assert validation.enabled is True
-    assert validation.validation_model is None
+    assert validation.model is None
     assert validation.forward_pydantic_model is True
     assert validation.leeway is None
     assert validation.allow_future_iat is None
@@ -638,9 +638,9 @@ def test_jwtvalidation_default_initialization():
 def test_jwtvalidation_custom_initialization():
     """Test JWTValidation with custom parameters."""
     now = datetime.now(UTC)
-    validation = JWTValidation(
+    validation = ValidationConfig(
         enabled=False,
-        validation_model=JWTClaims,
+        model=JWTClaims,
         forward_pydantic_model=False,
         leeway=10.0,
         allow_future_iat=True,
@@ -649,7 +649,7 @@ def test_jwtvalidation_custom_initialization():
     )
 
     assert validation.enabled is False
-    assert validation.validation_model == JWTClaims
+    assert validation.model == JWTClaims
     assert validation.forward_pydantic_model is False
     assert validation.leeway == 10.0
     assert validation.allow_future_iat is True
@@ -659,7 +659,7 @@ def test_jwtvalidation_custom_initialization():
 
 def test_jwtvalidation_apply_internal_cfg_with_none_model():
     """Test apply_internal_cfg uses defaults when model is None."""
-    validation = JWTValidation(
+    validation = ValidationConfig(
         leeway=None,
         allow_future_iat=None,
         jwtdatetime_force_int=None,
@@ -685,7 +685,7 @@ def test_jwtvalidation_apply_internal_cfg_inherits_from_model():
     model.spoof_time(custom_now)
 
     # Validation with all None values should inherit
-    validation = JWTValidation(
+    validation = ValidationConfig(
         leeway=None,
         allow_future_iat=None,
         jwtdatetime_force_int=None,
@@ -712,7 +712,7 @@ def test_jwtvalidation_apply_internal_cfg_does_not_override():
 
     # Validation with set values should NOT be overridden
     config_now = model_now + timedelta(hours=1)
-    validation = JWTValidation(
+    validation = ValidationConfig(
         leeway=7.0,
         allow_future_iat=False,
         jwtdatetime_force_int=True,
@@ -736,7 +736,7 @@ def test_jwtvalidation_apply_internal_cfg_mixed():
     model_now = datetime.now(UTC)
     model.spoof_time(model_now)
 
-    validation = JWTValidation(
+    validation = ValidationConfig(
         leeway=10.0,  # Set - should NOT be overridden
         allow_future_iat=None,  # None - should inherit True
         jwtdatetime_force_int=True,  # Set - should NOT be overridden
@@ -754,8 +754,8 @@ def test_jwtvalidation_apply_internal_cfg_mixed():
 def test_jwtvalidation_model_copy():
     """Test JWTValidation.model_copy creates independent copy."""
     now = datetime.now(UTC)
-    original = JWTValidation(
-        validation_model=JWTClaims,
+    original = ValidationConfig(
+        model=JWTClaims,
         leeway=10.0,
         allow_future_iat=True,
         now=now,
@@ -764,7 +764,7 @@ def test_jwtvalidation_model_copy():
     copy = original.model_copy(deep=True)
 
     # Verify values match
-    assert copy.validation_model == original.validation_model
+    assert copy.model == original.model
     assert copy.leeway == original.leeway
     assert copy.allow_future_iat == original.allow_future_iat
     assert copy.now == original.now
@@ -783,16 +783,16 @@ def test_jwtvalidation_forbids_extra_fields():
 
     # Should raise ValidationError when trying to set an invalid field
     with pytest.raises(pydantic.ValidationError, match="Extra inputs are not permitted"):
-        JWTValidation(
-            validation_model=JWTClaims,
+        ValidationConfig(
+            model=JWTClaims,
             invalid_field="some_value",  # type: ignore
         )
 
 
 def test_jwtvalidation_run_with_no_validation_model():
     """Test JWTValidation.run() raises error when validation_model is None."""
-    validation = JWTValidation(
-        validation_model=None,
+    validation = ValidationConfig(
+        model=None,
         enabled=True,
     )
 
@@ -805,8 +805,8 @@ def test_jwtvalidation_run_with_no_validation_model():
 
 def test_jwtvalidation_run_with_dict_data():
     """Test JWTValidation.run() with dict data."""
-    validation = JWTValidation(
-        validation_model=JWTClaims,
+    validation = ValidationConfig(
+        model=JWTClaims,
         enabled=True,
     )
 
@@ -825,8 +825,8 @@ def test_jwtvalidation_run_with_dict_data():
 
 def test_jwtvalidation_run_with_pydantic_data():
     """Test JWTValidation.run() with pydantic data."""
-    validation = JWTValidation(
-        validation_model=JWTClaims,
+    validation = ValidationConfig(
+        model=JWTClaims,
         enabled=True,
     )
 
@@ -840,8 +840,8 @@ def test_jwtvalidation_run_with_pydantic_data():
 
 def test_jwtvalidation_run_disabled():
     """Test JWTValidation.run() with validation disabled."""
-    validation = JWTValidation(
-        validation_model=None,
+    validation = ValidationConfig(
+        model=None,
         enabled=False,
     )
 
@@ -865,7 +865,7 @@ def test_jwtvalidation_run_disabled():
 def test_get_validation_config_disable_with_validation_none():
     """Test get_validation_config with validation=None (DISABLE)."""
     data = {"sub": "user123"}
-    default_validation = JWTValidation(validation_model=JWTClaims)
+    default_validation = ValidationConfig(model=JWTClaims)
 
     result = get_validation_config(
         data=data,
@@ -880,7 +880,7 @@ def test_get_validation_config_disable_with_validation_none():
 def test_get_validation_config_disable_with_validation_disable():
     """Test get_validation_config with validation=Validation.DISABLE."""
     data = ModelA(field_a="test")
-    default_validation = JWTValidation(validation_model=JWTClaims)
+    default_validation = ValidationConfig(model=JWTClaims)
 
     result = get_validation_config(
         data=data,
@@ -895,8 +895,8 @@ def test_get_validation_config_disable_with_validation_disable():
 def test_get_validation_config_disable_with_enabled_false():
     """Test get_validation_config with JWTValidation(enabled=False)."""
     data = {"sub": "user123"}
-    custom_validation = JWTValidation(enabled=False, validation_model=JWTClaims)
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    custom_validation = ValidationConfig(enabled=False, model=JWTClaims)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -919,8 +919,8 @@ def test_get_validation_config_default_with_pydantic_data_forward_true():
     Expected: validation_model should be data's type (ModelA), not default's model.
     """
     data = ModelA(field_a="test")
-    default_validation = JWTValidation(
-        validation_model=JWTBaseModel,
+    default_validation = ValidationConfig(
+        model=JWTBaseModel,
         forward_pydantic_model=True,
     )
 
@@ -931,7 +931,7 @@ def test_get_validation_config_default_with_pydantic_data_forward_true():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == ModelA
+    assert result.model == ModelA
     assert result.enabled is True
 
 
@@ -941,8 +941,8 @@ def test_get_validation_config_default_with_pydantic_data_forward_false():
     Expected: validation_model should be default's model (JWTBaseModel).
     """
     data = ModelA(field_a="test")
-    default_validation = JWTValidation(
-        validation_model=JWTBaseModel,
+    default_validation = ValidationConfig(
+        model=JWTBaseModel,
         forward_pydantic_model=False,
     )
 
@@ -953,7 +953,7 @@ def test_get_validation_config_default_with_pydantic_data_forward_false():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == JWTBaseModel
+    assert result.model == JWTBaseModel
     assert result.enabled is True
 
 
@@ -963,8 +963,8 @@ def test_get_validation_config_default_with_dict_data():
     Expected: validation_model should be default's model (no forwarding possible).
     """
     data = {"sub": "user123"}
-    default_validation = JWTValidation(
-        validation_model=JWTClaims,
+    default_validation = ValidationConfig(
+        model=JWTClaims,
         forward_pydantic_model=True,
     )
 
@@ -975,7 +975,7 @@ def test_get_validation_config_default_with_dict_data():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == JWTClaims
+    assert result.model == JWTClaims
     assert result.enabled is True
 
 
@@ -985,8 +985,8 @@ def test_get_validation_config_default_inherits_internal_config():
     data.set_leeway(20.0)
     data.allow_future_iat()
 
-    default_validation = JWTValidation(
-        validation_model=JWTBaseModel,
+    default_validation = ValidationConfig(
+        model=JWTBaseModel,
         forward_pydantic_model=True,
         leeway=None,  # Should inherit from data
         allow_future_iat=None,  # Should inherit from data
@@ -1014,11 +1014,11 @@ def test_get_validation_config_custom_jwtvalidation_with_pydantic_forward_true()
     Expected: If validation_model is None, forward data's type.
     """
     data = ModelA(field_a="test")
-    custom_validation = JWTValidation(
-        validation_model=None,
+    custom_validation = ValidationConfig(
+        model=None,
         forward_pydantic_model=True,
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1027,7 +1027,7 @@ def test_get_validation_config_custom_jwtvalidation_with_pydantic_forward_true()
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == ModelA
+    assert result.model == ModelA
     assert result.enabled is True
 
 
@@ -1037,11 +1037,11 @@ def test_get_validation_config_custom_jwtvalidation_with_explicit_model():
     Expected: validation_model should NOT be overridden by forwarding.
     """
     data = ModelA(field_a="test")
-    custom_validation = JWTValidation(
-        validation_model=ModelB,  # Explicit model
+    custom_validation = ValidationConfig(
+        model=ModelB,  # Explicit model
         forward_pydantic_model=True,  # Should NOT override explicit model
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1050,7 +1050,7 @@ def test_get_validation_config_custom_jwtvalidation_with_explicit_model():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == ModelB  # NOT ModelA
+    assert result.model == ModelB  # NOT ModelA
     assert result.enabled is True
 
 
@@ -1060,11 +1060,11 @@ def test_get_validation_config_custom_jwtvalidation_forward_false_no_model():
     Expected: validation_model should be None (invalid configuration).
     """
     data = ModelA(field_a="test")
-    custom_validation = JWTValidation(
-        validation_model=None,
+    custom_validation = ValidationConfig(
+        model=None,
         forward_pydantic_model=False,
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1073,18 +1073,18 @@ def test_get_validation_config_custom_jwtvalidation_forward_false_no_model():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model is None
+    assert result.model is None
     assert result.enabled is True
 
 
 def test_get_validation_config_custom_jwtvalidation_with_dict_data():
     """Test custom JWTValidation with dict data and explicit model."""
     data = {"sub": "user123"}
-    custom_validation = JWTValidation(
-        validation_model=JWTClaims,
+    custom_validation = ValidationConfig(
+        model=JWTClaims,
         leeway=15.0,
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1093,20 +1093,20 @@ def test_get_validation_config_custom_jwtvalidation_with_dict_data():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == JWTClaims
+    assert result.model == JWTClaims
     assert result.leeway == 15.0
     assert result.enabled is True
 
 
 def test_get_validation_config_custom_jwtvalidation_does_not_mutate():
     """Test that get_validation_config does not mutate input validation config."""
-    custom_validation = JWTValidation(
-        validation_model=JWTBaseModel,
+    custom_validation = ValidationConfig(
+        model=JWTBaseModel,
         leeway=10.0,
         allow_future_iat=False,
     )
     data = {"sub": "user123"}
-    default_validation = JWTValidation(validation_model=JWTClaims)
+    default_validation = ValidationConfig(model=JWTClaims)
 
     result = get_validation_config(
         data=data,
@@ -1130,13 +1130,13 @@ def test_get_validation_config_custom_jwtvalidation_inherits_from_model():
     data.set_leeway(30.0)
     data.force_jwtdatetime_to_float()
 
-    custom_validation = JWTValidation(
-        validation_model=None,
+    custom_validation = ValidationConfig(
+        model=None,
         forward_pydantic_model=True,
         leeway=None,  # Should inherit from data
         jwtdatetime_force_int=None,  # Should inherit from data
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1157,7 +1157,7 @@ def test_get_validation_config_custom_jwtvalidation_inherits_from_model():
 def test_get_validation_config_custom_model_class():
     """Test get_validation_config with model class as validation parameter."""
     data = {"sub": "user123"}
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1166,14 +1166,14 @@ def test_get_validation_config_custom_model_class():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == JWTClaims
+    assert result.model == JWTClaims
     assert result.enabled is True
 
 
 def test_get_validation_config_custom_model_class_with_pydantic_data():
     """Test get_validation_config with model class and pydantic data."""
     data = ModelA(field_a="test")
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1182,7 +1182,7 @@ def test_get_validation_config_custom_model_class_with_pydantic_data():
         fallback_data_model=JWTBaseModel,
     )
 
-    assert result.validation_model == ModelB  # NOT ModelA
+    assert result.model == ModelB  # NOT ModelA
     assert result.enabled is True
 
 
@@ -1194,13 +1194,13 @@ def test_get_validation_config_custom_model_class_with_pydantic_data():
 def test_get_validation_config_applies_defaults_for_dict_data():
     """Test get_validation_config applies defaults for dict data."""
     data = {"sub": "user123"}
-    custom_validation = JWTValidation(
-        validation_model=JWTClaims,
+    custom_validation = ValidationConfig(
+        model=JWTClaims,
         leeway=None,
         allow_future_iat=None,
         jwtdatetime_force_int=None,
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1220,12 +1220,12 @@ def test_get_validation_config_does_not_override_explicit_values():
     data = ModelA(field_a="test")
     data.set_leeway(50.0)
 
-    custom_validation = JWTValidation(
-        validation_model=None,
+    custom_validation = ValidationConfig(
+        model=None,
         forward_pydantic_model=True,
         leeway=10.0,  # Explicit - should NOT be overridden
     )
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result = get_validation_config(
         data=data,
@@ -1255,71 +1255,71 @@ def test_get_validation_config_all_combinations():
     7. Dict data + forward=False + validation_model=None → no model
     8. Dict data + forward=False + validation_model=Set → uses explicit model
     """
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     # Case 1: Pydantic + forward=True + model=None
     data_1 = ModelA(field_a="test")
-    validation_1 = JWTValidation(validation_model=None, forward_pydantic_model=True)
+    validation_1 = ValidationConfig(model=None, forward_pydantic_model=True)
     result_1 = get_validation_config(
         data_1, validation_1, default_validation, JWTBaseModel
     )
-    assert result_1.validation_model == ModelA
+    assert result_1.model == ModelA
 
     # Case 2: Pydantic + forward=True + model=Set
     data_2 = ModelA(field_a="test")
-    validation_2 = JWTValidation(validation_model=ModelB, forward_pydantic_model=True)
+    validation_2 = ValidationConfig(model=ModelB, forward_pydantic_model=True)
     result_2 = get_validation_config(
         data_2, validation_2, default_validation, JWTBaseModel
     )
-    assert result_2.validation_model == ModelB
+    assert result_2.model == ModelB
 
     # Case 3: Pydantic + forward=False + model=None
     data_3 = ModelA(field_a="test")
-    validation_3 = JWTValidation(validation_model=None, forward_pydantic_model=False)
+    validation_3 = ValidationConfig(model=None, forward_pydantic_model=False)
     result_3 = get_validation_config(
         data_3, validation_3, default_validation, JWTBaseModel
     )
-    assert result_3.validation_model is None
+    assert result_3.model is None
 
     # Case 4: Pydantic + forward=False + model=Set
     data_4 = ModelA(field_a="test")
-    validation_4 = JWTValidation(validation_model=ModelB, forward_pydantic_model=False)
+    validation_4 = ValidationConfig(model=ModelB, forward_pydantic_model=False)
     result_4 = get_validation_config(
         data_4, validation_4, default_validation, JWTBaseModel
     )
-    assert result_4.validation_model == ModelB
+    assert result_4.model == ModelB
 
     # Case 5: Dict + forward=True + model=None
     data_5 = {"sub": "user123"}
-    validation_5 = JWTValidation(validation_model=None, forward_pydantic_model=True)
+    validation_5 = ValidationConfig(model=None, forward_pydantic_model=True)
     result_5 = get_validation_config(
         data_5, validation_5, default_validation, JWTBaseModel
     )
-    assert result_5.validation_model is None
+    assert result_5.model is None
 
     # Case 6: Dict + forward=True + model=Set
     data_6 = {"sub": "user123"}
-    validation_6 = JWTValidation(validation_model=JWTClaims, forward_pydantic_model=True)
+    validation_6 = ValidationConfig(model=JWTClaims, forward_pydantic_model=True)
     result_6 = get_validation_config(
         data_6, validation_6, default_validation, JWTBaseModel
     )
-    assert result_6.validation_model == JWTClaims
+    assert result_6.model == JWTClaims
 
     # Case 7: Dict + forward=False + model=None
     data_7 = {"sub": "user123"}
-    validation_7 = JWTValidation(validation_model=None, forward_pydantic_model=False)
+    validation_7 = ValidationConfig(model=None, forward_pydantic_model=False)
     result_7 = get_validation_config(
         data_7, validation_7, default_validation, JWTBaseModel
     )
-    assert result_7.validation_model is None
+    assert result_7.model is None
 
     # Case 8: Dict + forward=False + model=Set
     data_8 = {"sub": "user123"}
-    validation_8 = JWTValidation(validation_model=JWTClaims, forward_pydantic_model=False)
+    validation_8 = ValidationConfig(model=JWTClaims, forward_pydantic_model=False)
     result_8 = get_validation_config(
         data_8, validation_8, default_validation, JWTBaseModel
     )
-    assert result_8.validation_model == JWTClaims
+    assert result_8.model == JWTClaims
 
 
 def test_get_validation_config_default_vs_custom():
@@ -1334,8 +1334,8 @@ def test_get_validation_config_default_vs_custom():
     data_pydantic = ModelA(field_a="test")
     data_dict = {"sub": "user123"}
 
-    default_validation = JWTValidation(
-        validation_model=JWTBaseModel,
+    default_validation = ValidationConfig(
+        model=JWTBaseModel,
         forward_pydantic_model=True,
         leeway=10.0,
     )
@@ -1344,33 +1344,33 @@ def test_get_validation_config_default_vs_custom():
     result_default_pydantic = get_validation_config(
         data_pydantic, Validation.DEFAULT, default_validation, JWTBaseModel
     )
-    assert result_default_pydantic.validation_model == ModelA
+    assert result_default_pydantic.model == ModelA
     assert result_default_pydantic.leeway == 10.0
 
     # Scenario 2: CUSTOM with explicit model uses explicit model
-    custom_validation = JWTValidation(
-        validation_model=JWTClaims,
+    custom_validation = ValidationConfig(
+        model=JWTClaims,
         forward_pydantic_model=True,
         leeway=7.0,
     )
     result_custom_pydantic = get_validation_config(
         data_pydantic, custom_validation, default_validation, JWTBaseModel
     )
-    assert result_custom_pydantic.validation_model == JWTClaims  # NOT ModelA
+    assert result_custom_pydantic.model == JWTClaims  # NOT ModelA
     assert result_custom_pydantic.leeway == 7.0  # NOT 10.0
 
     # Scenario 3: DEFAULT with dict data uses default's model
     result_default_dict = get_validation_config(
         data_dict, Validation.DEFAULT, default_validation, JWTBaseModel
     )
-    assert result_default_dict.validation_model == JWTBaseModel
+    assert result_default_dict.model == JWTBaseModel
     assert result_default_dict.leeway == 10.0
 
     # Scenario 4: CUSTOM with dict data uses custom model
     result_custom_dict = get_validation_config(
         data_dict, custom_validation, default_validation, JWTBaseModel
     )
-    assert result_custom_dict.validation_model == JWTClaims
+    assert result_custom_dict.model == JWTClaims
     assert result_custom_dict.leeway == 7.0
 
 
@@ -1382,7 +1382,7 @@ def test_get_validation_config_default_vs_custom():
 def test_get_validation_config_invalid_validation_type():
     """Test get_validation_config raises error for invalid validation type."""
     data = {"sub": "user123"}
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     with pytest.raises(TypeError, match="Wrong validation object type"):
         get_validation_config(
@@ -1397,7 +1397,7 @@ def test_get_validation_config_with_data_model_tracking():
     """Test get_validation_config properly tracks data_model."""
     data_pydantic = ModelA(field_a="test")
     data_dict = {"sub": "user123"}
-    default_validation = JWTValidation(validation_model=JWTBaseModel)
+    default_validation = ValidationConfig(model=JWTBaseModel)
 
     result_pydantic = get_validation_config(
         data_pydantic, Validation.DEFAULT, default_validation, JWTBaseModel


### PR DESCRIPTION
(breaking)

- rename `JWTValidation` to `ValidationConfig`
- rename `ValidationConfig.validation_model` to `ValidationConfig.model`