### PR TITLE
refactor: keys methods and optional public derivation

### DIFF
--- a/superjwt/keys.py
+++ b/superjwt/keys.py
@@ -37,10 +37,10 @@ class Key(ABC):
     @classmethod
     @abstractmethod
     def import_signing_key(cls, key: bytes | str) -> Self:
-        """Import a key for signing/encoding operations.
+        """Make a Key instance from the component needed for signing the JWT.
 
-        For symmetric keys: imports the secret key.
-        For asymmetric keys: imports the private key.
+        For symmetric keys: requires the secret key.
+        For asymmetric keys: requires the private key.
         """
         raise NotImplementedError(
             f"{cls.__name__} must implement import_signing_key()"
@@ -49,13 +49,21 @@ class Key(ABC):
     @classmethod
     @abstractmethod
     def import_verifying_key(cls, key: bytes | str) -> Self:
-        """Import a key for verification/decoding operations.
+        """Make a Key instance from the component needed for JWT verification.
 
-        For symmetric keys: imports the secret key (same as signing key).
-        For asymmetric keys: imports the public key.
+        For symmetric keys: requires the secret key.
+        For asymmetric keys: requires the public key.
         """
         raise NotImplementedError(
             f"{cls.__name__} must implement import_verifying_key()"
+        )  # pragma: no cover
+
+    @classmethod
+    @abstractmethod
+    def generate(cls, *args: object) -> Self:
+        """Generate a new Key instance."""
+        raise NotImplementedError(
+            f"{cls.__name__} must implement generate()"
         )  # pragma: no cover
 
     @abstractmethod
@@ -63,29 +71,43 @@ class Key(ABC):
         self,
         private_key: bytes | None = None,
         public_key: bytes | None = None,
-    ) -> None: ...  # pragma: no cover
+        derive_public_key: bool = True,
+    ) -> None:
+        """Prepare the key instance by loading the provided key components."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement _prepare_key()"
+        )  # pragma: no cover
 
     @classmethod
     def import_key(
-        cls, private_key: bytes | str | None = None, public_key: bytes | str | None = None
+        cls,
+        private_key: bytes | str | None = None,
+        public_key: bytes | str | None = None,
+        derive_public_key: bool = True,
     ) -> Self:
+        """Make a Key instance by importing key(s).
+
+        When importing an asymmetric key, if only the private key is provided,
+        the public key will be derived from it unless derive_public_key is False.
+        If both private_key and public_key are provided and derive_public_key is True,
+        they will be checked against each other for consistency.
+        """
         if cls is NoneKey:
             return cls()
 
         if private_key is None and public_key is None:
-            raise ValueError("Secret key must not be empty")
+            raise ValueError("No key was provided")
 
         if private_key is not None:
             private_key = as_bytes(private_key)
             if len(private_key) == 0:
-                raise ValueError("Secret key must not be empty")
+                raise ValueError("Private key must not be empty")
         if public_key is not None:
             public_key = as_bytes(public_key)
             if len(public_key) == 0:
-                raise ValueError("Secret key must not be empty")
-
+                raise ValueError("Public key must not be empty")
         key = cls()
-        key._prepare_key(private_key, public_key)
+        key._prepare_key(private_key, public_key, derive_public_key)
         return key
 
 
@@ -102,21 +124,23 @@ class NoneKey(Key):
     def import_verifying_key(cls, _) -> Self:
         return cls()
 
+    @classmethod
+    def generate(cls) -> Self:
+        return cls()  # pragma: no cover
+
     def _prepare_key(self, *_) -> None: ...
 
 
 class SymmetricKey(Key):
     @classmethod
     def import_signing_key(cls, key: bytes | str) -> Self:
-        """Import key for signing."""
-        return cls.import_key(key, None)
+        return cls.import_key(key)
 
     @classmethod
     def import_verifying_key(cls, key: bytes | str) -> Self:
-        """Import key for verification."""
-        return cls.import_key(key, None)
+        return cls.import_key(key)
 
-    def _prepare_key(self, secret_key: bytes, _) -> None:
+    def _prepare_key(self, secret_key: bytes, _, __) -> None:
         if _ is not None:
             raise SuperJWTError("Symmetric key should not have a public key component")
         if is_pem_format(secret_key) or is_ssh_key(secret_key):
@@ -204,16 +228,6 @@ class AsymmetricKey(Key, Generic[PrivateKeyType, PublicKeyType]):
         """Return tuple of valid public key types for isinstance checks."""
         ...  # pragma: no cover
 
-    @classmethod
-    def import_signing_key(cls, key: bytes | str) -> Self:
-        """Import private key for signing."""
-        return cls.import_key(key, None)
-
-    @classmethod
-    def import_verifying_key(cls, key: bytes | str) -> Self:
-        """Import public key for verification."""
-        return cls.import_key(None, key)
-
     @abstractmethod
     def check_key_security(self, key: PrivateKeyType | PublicKeyType) -> None:
         """Check key for security issues and emit warnings if needed.
@@ -225,35 +239,62 @@ class AsymmetricKey(Key, Generic[PrivateKeyType, PublicKeyType]):
 
     @abstractmethod
     def public_keys_match(self, key1: PublicKeyType, key2: PublicKeyType) -> bool:
-        """Compare two public keys for equality.
+        """Compare two public keys for equality."""
+        ...  # pragma: no cover
 
-        Returns:
-            True if the keys match, False otherwise
-        """  # pragma: no cover
-        ...
+    @classmethod
+    def import_signing_key(cls, key: bytes | str) -> Self:
+        return cls.import_private_key(key)
+
+    @classmethod
+    def import_verifying_key(cls, key: bytes | str) -> Self:
+        return cls.import_public_key(key)
+
+    @classmethod
+    def import_private_key(cls, key: bytes | str) -> Self:
+        """Make a Key instance from PEM private key."""
+        return cls.import_key(key, None, derive_public_key=False)
+
+    @classmethod
+    def import_public_key(cls, key: bytes | str) -> Self:
+        """Make a Key instance from PEM public key."""
+        return cls.import_key(None, key)
 
     def _prepare_key(
-        self, private_key: bytes | None = None, public_key: bytes | None = None
+        self,
+        private_key: bytes | None = None,
+        public_key: bytes | None = None,
+        derive_public_key: bool = True,
     ) -> None:
-        """
-        Prepare asymmetric key from PEM-encoded data.
-        Private keys contain both private and public components.
-        If only private_key is provided, the public key will be extracted from it.
-        If only public_key is provided, only verification operations will be available.
-        """
-
-        # Load private key if provided
+        # Private key loading
         if private_key is not None:
-            self._load_private_key(private_key)
-            assert self._private_key_obj is not None
+            self._private_key_obj = self._load_pem_private_key_common(private_key)
+            self.private_key = private_key
             self.check_key_security(self._private_key_obj)
 
-        # Load public key (either provided or derived from private key)
-        self._load_public_key(public_key)
+            # load public key from private key derivation if not provided
+            if public_key is None and derive_public_key:
+                derived_obj, derived_pem = self._derive_public_key_from_private()
+                self._public_key_obj = derived_obj
+                self.public_key = derived_pem
 
-        # Check security on the loaded public key (if not already checked via private key)
-        if private_key is None:
-            assert self._public_key_obj is not None
+            if public_key is not None and derive_public_key:
+                # check public key matches derived from private key
+                loaded_public_key_obj = self._load_pem_public_key_common(public_key)
+                derived_obj, derived_pem = self._derive_public_key_from_private()
+                if not self.public_keys_match(derived_obj, loaded_public_key_obj):
+                    raise InvalidKeyError(
+                        "Provided public key does not match the public key derived "
+                        "from the private key"
+                    )
+                self._public_key_obj = loaded_public_key_obj
+                self.public_key = public_key
+
+        # Public key loading
+        if private_key is None and public_key is not None:
+            # Load public key
+            self._public_key_obj = self._load_pem_public_key_common(public_key)
+            self.public_key = public_key
             self.check_key_security(self._public_key_obj)
 
     def _load_pem_private_key_common(self, private_key: bytes) -> PrivateKeyType:
@@ -295,59 +336,15 @@ class AsymmetricKey(Key, Generic[PrivateKeyType, PublicKeyType]):
             raise InvalidKeyError(f"Unable to parse {self.name} public key: {e}") from e
 
     def _derive_public_key_from_private(self) -> tuple[PublicKeyType, bytes]:
-        """Derive public key from the loaded private key.
-
-        Returns:
-            Tuple of (public_key_obj, public_key_pem)
-        """
-        assert self._private_key_obj is not None
+        """Derive public key from the loaded private key."""
+        if self._private_key_obj is None:
+            raise SuperJWTError("Cannot derive public key without a private key")
         derived_public_key_obj = cast("PublicKeyType", self._private_key_obj.public_key())
         derived_public_key_pem = derived_public_key_obj.public_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
         return derived_public_key_obj, derived_public_key_pem
-
-    def _load_private_key(self, private_key: bytes) -> None:
-        """Load a private key from PEM-encoded data.
-
-        Sets self._private_key_obj and self.private_key.
-        """
-        loaded_key = self._load_pem_private_key_common(private_key)
-        self._private_key_obj = loaded_key
-        self.private_key = private_key
-
-    def _load_public_key(self, public_key: bytes | None) -> None:
-        """Load a public key from PEM-encoded data.
-
-        If public_key is None and a private key exists, derives the public key from it.
-        Sets self._public_key_obj and self.public_key.
-        """
-        # If no public key provided, derive from private key
-        if public_key is None:
-            derived_obj, derived_pem = self._derive_public_key_from_private()
-            self._public_key_obj = derived_obj
-            self.public_key = derived_pem
-            return
-
-        # Load provided public key
-        loaded_key = self._load_pem_public_key_common(public_key)
-
-        # If private key exists, verify public key matches
-        if self._private_key_obj is not None:
-            derived_obj, derived_pem = self._derive_public_key_from_private()
-
-            if not self.public_keys_match(loaded_key, derived_obj):
-                raise InvalidKeyError(
-                    "Provided public key does not match the public key derived from the private key"
-                )
-
-            # Use the derived public key for consistency
-            self._public_key_obj = derived_obj
-            self.public_key = derived_pem
-        else:
-            self._public_key_obj = loaded_key
-            self.public_key = public_key
 
     def _get_private_key(self) -> PrivateKeyType:
         """Get the cryptography private key object for signing."""
@@ -419,12 +416,10 @@ class RSAKey(AsymmetricKey["rsa.RSAPrivateKey", "rsa.RSAPublicKey"]):
 
     @property
     def private_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid private key types."""
         return (rsa.RSAPrivateKey,)
 
     @property
     def public_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid public key types."""
         return (rsa.RSAPublicKey,)
 
     def check_key_security(self, key: rsa.RSAPrivateKey | rsa.RSAPublicKey) -> None:
@@ -437,7 +432,6 @@ class RSAKey(AsymmetricKey["rsa.RSAPrivateKey", "rsa.RSAPublicKey"]):
             )
 
     def public_keys_match(self, key1: rsa.RSAPublicKey, key2: rsa.RSAPublicKey) -> bool:
-        """Compare two RSA public keys for equality."""
         key1_numbers = key1.public_numbers()
         key2_numbers = key2.public_numbers()
 
@@ -487,7 +481,7 @@ class ECKey(AsymmetricKey["ec.EllipticCurvePrivateKey", "ec.EllipticCurvePublicK
         # Map string names to curve instances
         if isinstance(curve, str):
             curve_map = {
-                # Standard curve names
+                # by curve names
                 "P-256": ec.SECP256R1(),
                 "secp256r1": ec.SECP256R1(),
                 "P-384": ec.SECP384R1(),
@@ -495,7 +489,7 @@ class ECKey(AsymmetricKey["ec.EllipticCurvePrivateKey", "ec.EllipticCurvePublicK
                 "P-521": ec.SECP521R1(),
                 "secp521r1": ec.SECP521R1(),
                 "secp256k1": ec.SECP256K1(),
-                # Algorithm names
+                # by algorithm names
                 "ES256": ec.SECP256R1(),
                 "ES256K": ec.SECP256K1(),
                 "ES384": ec.SECP384R1(),
@@ -526,12 +520,10 @@ class ECKey(AsymmetricKey["ec.EllipticCurvePrivateKey", "ec.EllipticCurvePublicK
 
     @property
     def private_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid private key types."""
         return (ec.EllipticCurvePrivateKey,)
 
     @property
     def public_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid public key types."""
         return (ec.EllipticCurvePublicKey,)
 
     @property
@@ -615,12 +607,10 @@ class OKPKey(
 
     @property
     def private_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid private key types."""
         return (ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey)
 
     @property
     def public_key_types(self) -> tuple[type, ...]:
-        """Return tuple of valid public key types."""
         return (ed25519.Ed25519PublicKey, ed448.Ed448PublicKey)
 
     def check_key_security(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,8 +203,8 @@ class KeyPair(BaseModel):
             public_key_obj=key._public_key_obj,
             private_pem=key.private_key,
             public_pem=key.public_key,
-            key_instance_from_private_pem=type(key).import_signing_key(key.private_key),
-            key_instance_from_public_pem=type(key).import_verifying_key(key.public_key),
+            key_instance_from_private_pem=type(key).import_key(key.private_key),
+            key_instance_from_public_pem=type(key).import_public_key(key.public_key),
         )
 
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -411,7 +411,7 @@ class TestRSAAlgorithms:
         assert b"BEGIN RSA PRIVATE KEY" in pkcs1_pem
 
         # Should work with PKCS#1 format
-        rsa_key = RSAKey.import_signing_key(pkcs1_pem)
+        rsa_key = RSAKey.import_key(pkcs1_pem)
         algorithm = RS256Algorithm()
 
         signature = algorithm.sign(test_data, rsa_key)
@@ -431,7 +431,7 @@ class TestRSAAlgorithms:
         assert b"BEGIN PRIVATE KEY" in pkcs8_pem
 
         # Should work with PKCS#8 format
-        rsa_key = RSAKey.import_signing_key(pkcs8_pem)
+        rsa_key = RSAKey.import_key(pkcs8_pem)
         algorithm = RS256Algorithm()
 
         signature = algorithm.sign(test_data, rsa_key)
@@ -450,7 +450,7 @@ class TestRSAAlgorithms:
         assert b"BEGIN RSA PUBLIC KEY" in pkcs1_public_pem
 
         # Should work with PKCS#1 public format
-        public_key = RSAKey.import_verifying_key(pkcs1_public_pem)
+        public_key = RSAKey.import_public_key(pkcs1_public_pem)
 
         # Generate signature with private key
         private_pem = private_key_obj.private_bytes(
@@ -458,7 +458,7 @@ class TestRSAAlgorithms:
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=serialization.NoEncryption(),
         )
-        private_key = RSAKey.import_signing_key(private_pem)
+        private_key = RSAKey.import_private_key(private_pem)
 
         algorithm = RS256Algorithm()
         test_data = b"test data"
@@ -1028,7 +1028,7 @@ class TestEdDSAAlgorithms:
         ed448_algo = Ed448Algorithm()
 
         # Create a public-only key to test the public key validation path
-        ed25519_public_only = OKPKey.import_verifying_key(ed25519_key_pair.public_pem)
+        ed25519_public_only = OKPKey.import_public_key(ed25519_key_pair.public_pem)
 
         # Create a valid signature with Ed25519
         ed25519_algo = Ed25519Algorithm()
@@ -1047,7 +1047,7 @@ class TestEdDSAAlgorithms:
         ed25519_algo = Ed25519Algorithm()
 
         # Create a public-only key to test the public key validation path
-        ed448_public_only = OKPKey.import_verifying_key(ed448_key_pair.public_pem)
+        ed448_public_only = OKPKey.import_public_key(ed448_key_pair.public_pem)
 
         # Create a valid signature with Ed448
         ed448_algo = Ed448Algorithm()

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1092,8 +1092,8 @@ def test_rsa_pkcs1_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pa
         check_claims_instance(claims, decoded_with_private)
 
         # Scenario 2: Using RSAKey.import_signing_key() / RSAKey.import_verifying_key()
-        signing_key = RSAKey.import_signing_key(rsa_2048_key_pair.private_pem)
-        verifying_key = RSAKey.import_verifying_key(rsa_2048_key_pair.public_pem)
+        signing_key = RSAKey.import_private_key(rsa_2048_key_pair.private_pem)
+        verifying_key = RSAKey.import_public_key(rsa_2048_key_pair.public_pem)
 
         token2 = jwt.encode(claims, signing_key, alg).compact
         decoded_claims2 = JWTCustomClaims(
@@ -1102,7 +1102,7 @@ def test_rsa_pkcs1_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pa
         check_claims_instance(claims, decoded_claims2)
 
         # Scenario 3: Using RSAKey.import_key(private_key) for both encode and decode
-        combined_key = RSAKey.import_key(rsa_2048_key_pair.private_pem, None)
+        combined_key = RSAKey.import_key(rsa_2048_key_pair.private_pem)
 
         token3 = jwt.encode(claims, combined_key, alg).compact
         decoded_claims3 = JWTCustomClaims(**jwt.decode(token3, combined_key, alg).payload)
@@ -1135,8 +1135,8 @@ def test_rsa_pss_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pair
         check_claims_instance(claims, decoded_with_private)
 
         # Scenario 2: Using RSAKey.import_signing_key() / RSAKey.import_verifying_key()
-        signing_key = RSAKey.import_signing_key(rsa_2048_key_pair.private_pem)
-        verifying_key = RSAKey.import_verifying_key(rsa_2048_key_pair.public_pem)
+        signing_key = RSAKey.import_private_key(rsa_2048_key_pair.private_pem)
+        verifying_key = RSAKey.import_public_key(rsa_2048_key_pair.public_pem)
 
         token2 = jwt.encode(claims, signing_key, alg).compact
         decoded_claims2 = JWTCustomClaims(
@@ -1145,7 +1145,7 @@ def test_rsa_pss_algorithms(jwt: JWT, claims: JWTCustomClaims, rsa_2048_key_pair
         check_claims_instance(claims, decoded_claims2)
 
         # Scenario 3: Using RSAKey.import_key(private_key) for both encode and decode
-        combined_key = RSAKey.import_key(rsa_2048_key_pair.private_pem, None)
+        combined_key = RSAKey.import_key(rsa_2048_key_pair.private_pem)
 
         token3 = jwt.encode(claims, combined_key, alg).compact
         decoded_claims3 = JWTCustomClaims(**jwt.decode(token3, combined_key, alg).payload)
@@ -1183,8 +1183,8 @@ def test_ecdsa_algorithms(
         check_claims_instance(claims, decoded_with_private)
 
         # Scenario 2: Using ECKey.import_signing_key() / ECKey.import_verifying_key()
-        signing_key = ECKey.import_signing_key(key_pair.private_pem)
-        verifying_key = ECKey.import_verifying_key(key_pair.public_pem)
+        signing_key = ECKey.import_private_key(key_pair.private_pem)
+        verifying_key = ECKey.import_public_key(key_pair.public_pem)
 
         token2 = jwt.encode(claims, signing_key, alg).compact
         decoded_claims2 = JWTCustomClaims(
@@ -1193,7 +1193,7 @@ def test_ecdsa_algorithms(
         check_claims_instance(claims, decoded_claims2)
 
         # Scenario 3: Using ECKey.import_key(private_key) for both encode and decode
-        combined_key = ECKey.import_key(key_pair.private_pem, None)
+        combined_key = ECKey.import_key(key_pair.private_pem)
 
         token3 = jwt.encode(claims, combined_key, alg).compact
         decoded_claims3 = JWTCustomClaims(**jwt.decode(token3, combined_key, alg).payload)
@@ -1226,8 +1226,8 @@ def test_eddsa_algorithms(
         check_claims_instance(claims, decoded_with_private)
 
         # Scenario 2: Using OKPKey.import_signing_key() / OKPKey.import_verifying_key()
-        signing_key = OKPKey.import_signing_key(key_pair.private_pem)
-        verifying_key = OKPKey.import_verifying_key(key_pair.public_pem)
+        signing_key = OKPKey.import_private_key(key_pair.private_pem)
+        verifying_key = OKPKey.import_public_key(key_pair.public_pem)
 
         token2 = jwt.encode(claims, signing_key, alg).compact
         decoded_claims2 = JWTCustomClaims(
@@ -1236,7 +1236,7 @@ def test_eddsa_algorithms(
         check_claims_instance(claims, decoded_claims2)
 
         # Scenario 3: Using OKPKey.import_key(private_key) for both encode and decode
-        combined_key = OKPKey.import_key(key_pair.private_pem, None)
+        combined_key = OKPKey.import_key(key_pair.private_pem)
 
         token3 = jwt.encode(claims, combined_key, alg).compact
         decoded_claims3 = JWTCustomClaims(**jwt.decode(token3, combined_key, alg).payload)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -85,17 +85,17 @@ class TestOctKey:
 
     def test_oct_key_empty_string_raises_error(self):
         """Test that empty string raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Private key must not be empty"):
             OctKey.import_key("")
 
     def test_oct_key_empty_bytes_raises_error(self):
         """Test that empty bytes raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Private key must not be empty"):
             OctKey.import_key(b"")
 
     def test_oct_key_none_raises_error(self):
         """Test that None raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="No key was provided"):
             OctKey.import_key(None)  # type: ignore
 
     def test_oct_key_rejects_pem_format(self):
@@ -151,7 +151,7 @@ MIIEpAIBAAKCAQEA4Z9v...
 
     def test_oct_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Public key must not be empty"):
             OctKey.import_key(None, b"")
 
     def test_oct_key_public_key_not_allowed(self):
@@ -351,12 +351,12 @@ invalid base64 data!!!
 
     def test_rsa_key_empty_string_raises_error(self):
         """Test that empty string raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Private key must not be empty"):
             RSAKey.import_key("")
 
     def test_rsa_key_none_raises_error(self):
         """Test that None raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="No key was provided"):
             RSAKey.import_key(None)  # type: ignore
 
     def test_rsa_key_both_keys_valid_match(
@@ -390,9 +390,9 @@ invalid base64 data!!!
         key = RSAKey.import_signing_key(rsa_private_key_pkcs1)
         assert isinstance(key, RSAKey)
         assert key.private_key == rsa_private_key_pkcs1
-        assert key.public_key != b""
+        assert key.public_key == b""  # No derivation with import_signing_key
         assert key._private_key_obj is not None
-        assert key._public_key_obj is not None
+        assert key._public_key_obj is None  # Not derived
 
     def test_rsa_key_import_verifying_key(self, rsa_public_key_spki):
         """Test importing RSAKey via import_verifying_key with public key."""
@@ -451,7 +451,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_rsa_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Public key must not be empty"):
             RSAKey.import_key(None, b"")
 
     def test_rsa_key_public_keys_match_returns_true(self, rsa_private_key_pkcs1):
@@ -491,7 +491,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_rsa_key_export_public_key_pem(self, rsa_2048_key_pair):
         """Test exporting public key as PEM."""
-        key = rsa_2048_key_pair.key_instance_from_private_pem
+        key = RSAKey.import_key(rsa_2048_key_pair.private_pem)
         pem = key.export_public_key_pem()
 
         assert isinstance(pem, bytes)
@@ -630,12 +630,12 @@ invalid base64 data!!!
 
     def test_ec_key_empty_string_raises_error(self):
         """Test that empty string raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Private key must not be empty"):
             ECKey.import_key("")
 
     def test_ec_key_none_raises_error(self):
         """Test that None raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="No key was provided"):
             ECKey.import_key(None)  # type: ignore
 
     def test_ec_key_both_keys_valid_match(self, ec_private_key_p256, ec_public_key_p256):
@@ -667,9 +667,9 @@ invalid base64 data!!!
         key = ECKey.import_signing_key(ec_private_key_p256)
         assert isinstance(key, ECKey)
         assert key.private_key == ec_private_key_p256
-        assert key.public_key != b""
+        assert key.public_key == b""  # No derivation with import_signing_key
         assert key._private_key_obj is not None
-        assert key._public_key_obj is not None
+        assert key._public_key_obj is None  # Not derived
 
     def test_ec_key_import_verifying_key(self, ec_public_key_p256):
         """Test importing ECKey via import_verifying_key with public key."""
@@ -728,7 +728,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_ec_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Public key must not be empty"):
             ECKey.import_key(None, b"")
 
     def test_ec_key_public_keys_match_returns_true(self, ec_private_key_p256):
@@ -778,7 +778,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_ec_key_export_public_key_pem(self, ec_p256_key_pair):
         """Test exporting public key as PEM."""
-        key = ec_p256_key_pair.key_instance_from_private_pem
+        key = ECKey.import_key(ec_p256_key_pair.private_pem)
         pem = key.export_public_key_pem()
 
         assert isinstance(pem, bytes)
@@ -793,6 +793,24 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
         """Test getting curve key size from public-only key."""
         key = ECKey.import_key(public_key=ec_public_key_p256)
         assert key.curve_key_size == 256
+
+    def test_ec_key_curve_name_from_private_key(self, ec_private_key_p256):
+        """Test getting curve name from private key."""
+        key = ECKey.import_key(ec_private_key_p256)
+        assert key.curve_name == "secp256r1"
+
+    def test_ec_key_curve_key_size_from_private_key(self, ec_private_key_p256):
+        """Test getting curve key size from private key."""
+        key = ECKey.import_key(ec_private_key_p256)
+        assert key.curve_key_size == 256
+
+    def test_ec_key_derive_public_key_without_private_raises_error(self):
+        """Test that deriving public key without private key raises error."""
+        key = ECKey()
+        with pytest.raises(
+            SuperJWTError, match="Cannot derive public key without a private key"
+        ):
+            key._derive_public_key_from_private()
 
 
 @requires_cryptography
@@ -923,12 +941,12 @@ invalid base64 data!!!
 
     def test_okp_key_empty_string_raises_error(self):
         """Test that empty string raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Private key must not be empty"):
             OKPKey.import_key("")
 
     def test_okp_key_none_raises_error(self):
         """Test that None raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="No key was provided"):
             OKPKey.import_key(None)  # type: ignore
 
     def test_okp_key_both_keys_valid_match(
@@ -962,9 +980,9 @@ invalid base64 data!!!
         key = OKPKey.import_signing_key(okp_private_key_ed25519)
         assert isinstance(key, OKPKey)
         assert key.private_key == okp_private_key_ed25519
-        assert key.public_key != b""
+        assert key.public_key == b""  # No derivation with import_signing_key
         assert key._private_key_obj is not None
-        assert key._public_key_obj is not None
+        assert key._public_key_obj is None  # Not derived
 
     def test_okp_key_import_verifying_key(self, okp_public_key_ed25519):
         """Test importing OKPKey via import_verifying_key with public key."""
@@ -1007,7 +1025,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_okp_key_empty_public_key_raises_error(self):
         """Test that empty public_key parameter raises ValueError."""
-        with pytest.raises(ValueError, match="Secret key must not be empty"):
+        with pytest.raises(ValueError, match="Public key must not be empty"):
             OKPKey.import_key(None, b"")
 
     def test_okp_key_public_keys_match_returns_true(self, ed25519_key_pair):
@@ -1055,7 +1073,7 @@ CORRUPTED_DATA_HERE_NOT_VALID_BASE64!!!
 
     def test_okp_key_export_public_key_pem(self, ed25519_key_pair):
         """Test exporting public key as PEM."""
-        key = ed25519_key_pair.key_instance_from_private_pem
+        key = OKPKey.import_key(ed25519_key_pair.private_pem)
         pem = key.export_public_key_pem()
 
         assert isinstance(pem, bytes)


### PR DESCRIPTION
- :art: better code structure for _prepare_key() in asymmetric
- :zap: choose to not always derive the public key (when encoding with a signing key from raw pem key)