### PR TITLE
refactor: trim msg in exceptions from uncontrolled data

### DIFF
--- a/superjwt/exceptions.py
+++ b/superjwt/exceptions.py
@@ -1,4 +1,7 @@
-from pydantic_core import ErrorDetails
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from superjwt.utils import pydantic_validation_errors_to_str
 
 
 class SecurityWarning(UserWarning):
@@ -57,16 +60,12 @@ class HeadersValidationError(InvalidHeadersError):
     def __init__(
         self,
         message: str | None = None,
-        validation_errors: list[ErrorDetails] | None = None,
+        validation_errors: Sequence[Mapping[str, Any]] | None = None,
     ):
         self.error = message or self.error
         if validation_errors is not None:
             self.error += "\n"
-            self.error += "\n".join(
-                f"header {error['loc'] if error['loc'] else ''} = {error['input']} "
-                f"-> validation failed ({error['type']}): {error['msg']}"
-                for error in validation_errors
-            )
+            self.error += pydantic_validation_errors_to_str(validation_errors)
         super().__init__(self.error)
 
 
@@ -89,16 +88,12 @@ class ClaimsValidationError(InvalidPayloadError):
     def __init__(
         self,
         message: str | None = None,
-        validation_errors: list[ErrorDetails] | None = None,
+        validation_errors: Sequence[Mapping[str, Any]] | None = None,
     ):
         self.error = message or self.error
         if validation_errors is not None:
             self.error += "\n"
-            self.error += "\n".join(
-                f"claim {error['loc'] if error['loc'] else ''} = {error['input']} "
-                f"-> validation failed ({error['type']}): {error['msg']}"
-                for error in validation_errors
-            )
+            self.error += pydantic_validation_errors_to_str(validation_errors)
         super().__init__(self.error)
 
 

--- a/superjwt/jws.py
+++ b/superjwt/jws.py
@@ -16,7 +16,7 @@ from superjwt.exceptions import (
     SuperJWTError,
 )
 from superjwt.keys import Key
-from superjwt.utils import as_bytes, urlsafe_b64decode, urlsafe_b64encode
+from superjwt.utils import as_bytes, trim_str, urlsafe_b64decode, urlsafe_b64encode
 from superjwt.validations import (
     JOSEHeader,
     JWTBaseModel,
@@ -273,7 +273,7 @@ class JWS:
         pass_through = self.algorithm.name == "none" and self._allow_none_algorithm
         if not pass_through and headers_validated.alg != self.algorithm.name:
             raise AlgorithmMismatchError(
-                f"JWS algorithm '{headers_validated.alg}' does not match expected '{self.algorithm.name}'"
+                f"JWS algorithm '{trim_str(headers_validated.alg, 16)}' does not match expected '{self.algorithm.name}'"
             )
 
     def verify_signature(self, key: Key) -> bool:

--- a/superjwt/utils.py
+++ b/superjwt/utils.py
@@ -1,7 +1,9 @@
 import base64
 import binascii
 import re
+from collections.abc import Mapping, Sequence
 from datetime import datetime
+from typing import Any
 
 
 def check_cryptography_available(raise_error: bool = True) -> bool:
@@ -20,6 +22,23 @@ def check_cryptography_available(raise_error: bool = True) -> bool:
 
 
 CRYPTOGRAPHY_AVAILABLE = check_cryptography_available(raise_error=False)
+
+
+def trim_str(s: str, max_length: int = 200) -> str:
+    if len(s) <= max_length:
+        return s
+    return s[:max_length] + "..."
+
+
+def pydantic_validation_errors_to_str(
+    validation_errors: Sequence[Mapping[str, Any]],
+) -> str:
+    error = "\n".join(
+        f"{trim_str(str(error['loc']), 64) if error['loc'] else ''} = {trim_str(str(error['input']))} "
+        f"-> validation failed ({error['type']}): {error['msg']}"
+        for error in validation_errors
+    )
+    return error
 
 
 def as_bytes(s: str | bytes) -> bytes:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from superjwt.utils import (
     encode_integer,
     is_pem_format,
     is_ssh_key,
+    pydantic_validation_errors_to_str,
+    trim_str,
     urlsafe_b64decode,
     urlsafe_b64encode,
 )
@@ -99,6 +101,74 @@ def test_as_bytes():
     assert as_bytes(b"foo") == b"foo"
     with pytest.raises(TypeError):
         as_bytes(123)  # type: ignore
+
+
+def test_trim_str():
+    # Shorter than max_length -> unchanged
+    s_short = "a" * 10
+    assert trim_str(s_short, max_length=20) == s_short
+
+    # Exactly at max_length -> unchanged
+    s_exact = "x" * 200
+    assert trim_str(s_exact) == s_exact
+
+    # Longer than default max_length -> truncated with ellipsis
+    s_long = "y" * 250
+    trimmed = trim_str(s_long)
+    assert trimmed.endswith("...")
+    assert len(trimmed) == 200 + 3
+
+    # Custom max_length
+    assert trim_str("abcdef", max_length=3) == "abc..."
+
+
+def test_pydantic_validation_errors_to_str():
+    """Test formatting pydantic validation errors with trimming."""
+    # Basic case with normal-sized inputs
+    err1 = {
+        "loc": ("field", "sub"),
+        "input": "test_value",
+        "type": "value_error",
+        "msg": "invalid",
+    }
+    result = pydantic_validation_errors_to_str([err1])
+    assert "('field', 'sub')" in result
+    assert "test_value" in result
+    assert "validation failed (value_error)" in result
+    assert "invalid" in result
+
+    # Empty loc
+    err2 = {"loc": (), "input": 123, "type": "type_error", "msg": "wrong type"}
+    result = pydantic_validation_errors_to_str([err2])
+    assert result.startswith(" = 123")
+    assert "validation failed (type_error): wrong type" in result
+
+    # Long input gets trimmed (250 chars -> 200 + "...")
+    long_input = "x" * 250
+    err3 = {
+        "loc": ("field",),
+        "input": long_input,
+        "type": "value_error",
+        "msg": "too long",
+    }
+    result = pydantic_validation_errors_to_str([err3])
+    assert "x" * 200 + "..." in result
+    assert "x" * 201 not in result  # Verify it was actually trimmed
+
+    # Long loc gets trimmed (max_length=64 for loc)
+    long_loc = ("a" * 100, "b" * 100)
+    err4 = {"loc": long_loc, "input": "val", "type": "value_error", "msg": "test"}
+    result = pydantic_validation_errors_to_str([err4])
+    # str(long_loc) is longer than 64, should be trimmed
+    assert "..." in result
+    assert len(result.split(" = ")[0]) == 67  # 64 chars + "..."
+
+    # Multiple errors joined by newline
+    result_multi = pydantic_validation_errors_to_str([err1, err2])
+    lines = result_multi.split("\n")
+    assert len(lines) == 2
+    assert "('field', 'sub')" in lines[0]
+    assert " = 123" in lines[1]
 
 
 def test_is_pem_format():


### PR DESCRIPTION
Control the string size output in exceptions when data comes from possibly uncontrolled data. This is an additional security check, given the total token size is already controlled (default 16KB max)