### PR TITLE
refactor: simplify algorithm instances cache

### DIFF
--- a/superjwt/shared.py
+++ b/superjwt/shared.py
@@ -1,4 +1,3 @@
-# Global algorithm instance cache for performance optimization
 from enum import Enum
 
 from typing_extensions import Self
@@ -38,28 +37,25 @@ def get_max_token_bytes() -> int:
     return MAX_TOKEN_BYTES
 
 
-_ALGORITHM_INSTANCES: dict[str, BaseJWSAlgorithm] = {}
-
-
-ALGORITHMS: dict[str, type[BaseJWSAlgorithm] | None] = {
+ALGORITHMS: dict[str, BaseJWSAlgorithm | None] = {
     # frequently used
-    "HS256": HS256Algorithm,
-    "Ed25519": Ed25519Algorithm,
-    "RS256": RS256Algorithm,
-    "PS256": PS256Algorithm,
+    "HS256": HS256Algorithm(),
+    "Ed25519": Ed25519Algorithm(),
+    "RS256": RS256Algorithm(),
+    "PS256": PS256Algorithm(),
     # less frequently used
-    "HS384": HS384Algorithm,
-    "HS512": HS512Algorithm,
-    "RS384": RS384Algorithm,
-    "RS512": RS512Algorithm,
-    "PS384": PS384Algorithm,
-    "PS512": PS512Algorithm,
-    "ES256": ES256Algorithm,
-    "ES256K": ES256KAlgorithm,
-    "ES384": ES384Algorithm,
-    "ES512": ES512Algorithm,
+    "HS384": HS384Algorithm(),
+    "HS512": HS512Algorithm(),
+    "RS384": RS384Algorithm(),
+    "RS512": RS512Algorithm(),
+    "PS384": PS384Algorithm(),
+    "PS512": PS512Algorithm(),
+    "ES256": ES256Algorithm(),
+    "ES256K": ES256KAlgorithm(),
+    "ES384": ES384Algorithm(),
+    "ES512": ES512Algorithm(),
     "EdDSA": None,  # Deprecated and not supported
-    "Ed448": Ed448Algorithm,
+    "Ed448": Ed448Algorithm(),
 }
 
 
@@ -67,10 +63,10 @@ def preload_algorithm_headers() -> dict[bytes, str]:
     """Preload encoded headers for all supported algorithms and create reverse lookup."""
     reverse_lookup: dict[bytes, str] = {}
 
-    for alg_name, alg_class in ALGORITHMS.items():
-        if alg_class is not None:
-            headers_with_typ = alg_class.default_encoded_headers
-            headers_without_typ = alg_class.default_encoded_headers_without_typ
+    for alg_name, alg_instance in ALGORITHMS.items():
+        if alg_instance is not None:
+            headers_with_typ = alg_instance.default_encoded_headers
+            headers_without_typ = alg_instance.default_encoded_headers_without_typ
 
             reverse_lookup[headers_with_typ] = alg_name
             reverse_lookup[headers_without_typ] = alg_name
@@ -104,14 +100,6 @@ class Alg(str, Enum):
     def get_instance(self) -> BaseJWSAlgorithm:
         return get_cached_algorithm(self.value)
 
-    @staticmethod
-    def get_instance_by_name(name: str) -> BaseJWSAlgorithm:
-        if name not in ALGORITHMS:
-            raise InvalidAlgorithmError(
-                f"Algorithm '{name}' is not a valid JWS algorithm"
-            )
-        return getattr(Alg, name).get_instance()
-
     @classmethod
     def get_algorithm(cls, algorithm: Self | str) -> BaseJWSAlgorithm:
         if isinstance(algorithm, cls):
@@ -125,34 +113,18 @@ class Alg(str, Enum):
         return _PRELOADED_HEADERS_TO_ALGORITHM.get(encoded_headers)
 
 
-SUPPORTED_ALGORITHMS = Alg.__members__.keys()
-
-
-def _initialize_algorithm_cache() -> None:
-    """Initialize the global algorithm instance cache."""
-    global _ALGORITHM_INSTANCES
-
-    for alg_name in ALGORITHMS.keys():
-        alg_class = ALGORITHMS.get(alg_name)
-        if alg_class is not None:
-            _ALGORITHM_INSTANCES[alg_name] = alg_class()
-
-
-# Initialize the cache when the module is imported
-_initialize_algorithm_cache()
+VALID_ALGORITHMS = Alg.__members__.keys()
 
 
 def get_cached_algorithm(algorithm_name: str) -> BaseJWSAlgorithm:
     """Get a cached algorithm instance by name."""
-    if algorithm_name not in _ALGORITHM_INSTANCES:
-        if algorithm_name not in ALGORITHMS:
-            raise InvalidAlgorithmError(
-                f"Algorithm '{algorithm_name}' is not a valid JWS algorithm"
-            )
-        # Check if algorithm is explicitly marked as not implemented
-        if ALGORITHMS[algorithm_name] is None:
-            raise AlgorithmNotSupportedError(
-                f"JWS Algorithm '{algorithm_name}' is not yet implemented"
-            )
-
-    return _ALGORITHM_INSTANCES[algorithm_name]
+    if algorithm_name not in ALGORITHMS:
+        raise InvalidAlgorithmError(
+            f"Algorithm '{algorithm_name}' is not a valid JWS algorithm"
+        )
+    alg = ALGORITHMS[algorithm_name]
+    if alg is None:
+        raise AlgorithmNotSupportedError(
+            f"JWS Algorithm '{algorithm_name}' is not yet implemented"
+        )
+    return alg

--- a/superjwt/validations.py
+++ b/superjwt/validations.py
@@ -20,7 +20,7 @@ from superjwt.exceptions import (
     TokenExpiredError,
     TokenNotYetValidError,
 )
-from superjwt.shared import SUPPORTED_ALGORITHMS
+from superjwt.shared import VALID_ALGORITHMS
 from superjwt.utils import delta_datetime_timestamp
 
 
@@ -95,7 +95,7 @@ class JOSEHeader(JWTBaseModel):
         """Validate that the algorithm is a valid algorithm name and normalize to string."""
 
         # Check if it's a valid algorithm
-        if value not in SUPPORTED_ALGORITHMS:
+        if value not in VALID_ALGORITHMS:
             raise ValueError(f"'{value}' is not a valid algorithm")
 
         return value

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,8 +1,9 @@
 import pytest
+from superjwt.algorithms import BaseJWSAlgorithm
 from superjwt.exceptions import AlgorithmNotSupportedError, InvalidAlgorithmError
 from superjwt.shared import (
     ALGORITHMS,
-    SUPPORTED_ALGORITHMS,
+    VALID_ALGORITHMS,
     Alg,
     get_cached_algorithm,
     get_max_token_bytes,
@@ -13,7 +14,7 @@ from superjwt.shared import (
 # These imports are used in the test functions below
 _ = (
     ALGORITHMS,
-    SUPPORTED_ALGORITHMS,
+    VALID_ALGORITHMS,
     get_cached_algorithm,
     get_max_token_bytes,
     set_max_token_bytes,
@@ -31,30 +32,9 @@ class TestAlgEnum:
         ):
             Alg.EdDSA.get_instance()
 
-    def test_get_instance_by_name_invalid_algorithm(self):
-        """Test that get_instance_by_name() raises InvalidAlgorithmError for invalid algorithm names."""
-        with pytest.raises(
-            InvalidAlgorithmError, match=r"INVALID.*not a valid JWS algorithm"
-        ):
-            Alg.get_instance_by_name("INVALID")
-
-    def test_get_instance_by_name_not_implemented(self):
-        """Test that get_instance_by_name() raises AlgorithmNotSupportedError for unimplemented algorithms."""
-        # EdDSA is defined but not yet implemented (ALGORITHMS[EdDSA] = None)
-        with pytest.raises(
-            AlgorithmNotSupportedError, match=r"EdDSA.*not yet implemented"
-        ):
-            Alg.get_instance_by_name("EdDSA")
-
     def test_get_instance_success(self):
         """Test that get_instance() successfully returns an algorithm instance for implemented algorithms."""
         instance = Alg.HS256.get_instance()
-        assert instance is not None
-        assert instance.__class__.__name__ == "HS256Algorithm"
-
-    def test_get_instance_by_name_success(self):
-        """Test that get_instance_by_name() successfully returns an algorithm instance for implemented algorithms."""
-        instance = Alg.get_instance_by_name("HS256")
         assert instance is not None
         assert instance.__class__.__name__ == "HS256Algorithm"
 
@@ -116,13 +96,6 @@ class TestAlgEnum:
         """Test that get_instance() returns the same cached instance."""
         instance1 = Alg.HS256.get_instance()
         instance2 = Alg.HS256.get_instance()
-        # Should be the exact same object (cached)
-        assert instance1 is instance2
-
-    def test_get_instance_by_name_caches_instances(self):
-        """Test that get_instance_by_name() returns cached instances."""
-        instance1 = Alg.get_instance_by_name("RS256")
-        instance2 = Alg.get_instance_by_name("RS256")
         # Should be the exact same object (cached)
         assert instance1 is instance2
 
@@ -299,7 +272,7 @@ class TestALGORITHMS:
 
         for alg_name in implemented_algorithms:
             assert ALGORITHMS[alg_name] is not None
-            assert callable(ALGORITHMS[alg_name])
+            assert isinstance(ALGORITHMS[alg_name], BaseJWSAlgorithm)
 
     def test_algorithms_dict_eddsa_is_none(self):
         """Test that EdDSA algorithm is marked as not implemented (None)."""
@@ -335,7 +308,7 @@ class TestSupportedAlgorithms:
     def test_supported_algorithms_matches_alg_enum(self):
         """Test that SUPPORTED_ALGORITHMS contains all Alg enum member names."""
         expected = set(Alg.__members__.keys())
-        actual = set(SUPPORTED_ALGORITHMS)
+        actual = set(VALID_ALGORITHMS)
         assert actual == expected
 
     def test_supported_algorithms_includes_all_algorithms(self):
@@ -359,12 +332,12 @@ class TestSupportedAlgorithms:
             "Ed448",
         }
 
-        assert set(SUPPORTED_ALGORITHMS) == expected_algorithms
+        assert set(VALID_ALGORITHMS) == expected_algorithms
 
     def test_supported_algorithms_is_iterable(self):
         """Test that SUPPORTED_ALGORITHMS can be iterated."""
         count = 0
-        for alg_name in SUPPORTED_ALGORITHMS:
+        for alg_name in VALID_ALGORITHMS:
             assert isinstance(alg_name, str)
             count += 1
 


### PR DESCRIPTION
Given we don't have `cryptography` as an optional dependency, we can now store instances directly as globals. Also, `SUPPORTED_ALGORITHMS` was renamed `VALID_ALGORITHMS`.